### PR TITLE
Support bwm stop processing new jobs when a file changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
@flodnv please review. /cc @coleaeason 

Needed for https://github.com/Expensify/Expensify/issues/40404

Web and Salt PRs incoming. We can merge this anyway, since no one will be using this version of the lib.

Tests:
- Invoke bwm without the versionWatchFile param. Check it works.
- Invoke bwm with the versionWatchFile param:
  - Check it works if the file doesn't exist.
  - Check that it stops processing new jobs when the file time changes.
  - Check that it waits till all processing jobs finish before dying.
- Bonus feature: You can now stop bwm on dev with CTRL+C 😄 