### PR TITLE
Fix param type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -18,7 +18,7 @@ class RetryableException extends BedrockError
     /**
      * RetryableException constructor.
      *
-     * @param int            $message  Message of the exception
+     * @param string         $message  Message of the exception
      * @param int            $delay    Time (in seconds)  to delay the retry.
      * @param int            $code     Code of the exception
      * @param Exception|null $previous


### PR DESCRIPTION
The type for `$message` should be a string, not int.