### PR TITLE
Allow setting of connection header for queueJob

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
@iwiznia Please review these changes.

Added additional params to `queueJob` and `createJob` to allow setting the `'Connection'` header.

Reference: https://github.com/Expensify/Web-Expensify/pull/16198#discussion_r98462964

### Tests
Tested with changes in https://github.com/Expensify/Web-Expensify/pull/16198
1. Uploaded Square receipt into dev.
2. After parsing completed, changed the category from Uncategorized to a category that has a mapped MCC in the policy settings.
3. Confirmed www-prod/UpdateMerchantToMCCUsage was queued in the jobs table and returned `202` code success code.