### PR TITLE
Catch throwable

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -206,7 +206,7 @@ try {
                                 'extraParams' => $extraParams,
                             ]);
                             $bedrock->jobs->retryJob($job['jobID'], $e->getDelay(), $worker->getData());
-                        } catch (Exception $e) {
+                        } catch (Throwable $e) {
                             $logger->alert("Job failed with errors, exiting.", [
                                 'name' => $job['name'],
                                 'id' => $job['jobID'],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "authors": [
         {
             "name": "Expensify",

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo Current version:
+sed -n -e '/"version"/p' composer.json
+
+echo What is the new version?
+read targetVersion
+
+sed -i -e 's/"version": "[0-9]*\.[0-9]*\.[0-9]*",/"version": "'$targetVersion'",/g' composer.json
+
+echo Committing build
+git add .
+git commit -m "build version $targetVersion"
+
+echo Tagging release...
+git tag -a "$targetVersion" -m "$targetVersion"
+
+echo Pushing tag
+git push origin --tags


### PR DESCRIPTION
This will allow us to catch php errors that go uncatched now, like [this one](https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:("vqgsba")+AND+timestamp:[2017-02-01T14:41:16.679Z+TO+2017-02-01T16:41:16.679Z]&index=logs_2017-02-01)

Tests:
In BWM we log the exception as a param, since the LoggerInterface doesn't have `->exception` as a method like `Log` does.
```
$caca = null;
try {
    $caca->caca();
} catch (Throwable $e) {
    Log::alert('Yay!', ['error' => $e]);
}
```
Log:
```
Feb 17 15:50:46 vagrant-ubuntu-trusty-64 php-cgi: wmNorj /caca.php ionatan@expensify.com !web! ?api? [alrt] Yay! ~~ error: 'Error: Call to a member function caca() on null in /vagrant/Web-Expensify/caca.php:7#012Stack trace:#012#0 {main}'
```