### PR TITLE
Remove + and / from REQUEST_ID

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -186,7 +186,7 @@ try {
                         // Reset the REQUEST_ID and re-log the line so we see
                         // it when searching for either the parent and child
                         // REQUEST_IDs.
-                        $GLOBALS['REQUEST_ID'] = substr(str_replace(['+','/'], '', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
+                        $GLOBALS['REQUEST_ID'] = substr(str_replace(['+','/'], 'x', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
                         $logger->info("Fork succeeded, child process, running job", [
                             'name' => $job['name'],
                             'id' => $job['jobID'],

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -186,7 +186,7 @@ try {
                         // Reset the REQUEST_ID and re-log the line so we see
                         // it when searching for either the parent and child
                         // REQUEST_IDs.
-                        $GLOBALS['REQUEST_ID'] = substr(base64_encode(openssl_random_pseudo_bytes(6)), 0, 6); // random 6 character ID
+                        $GLOBALS['REQUEST_ID'] = substr(str_replace(['+','/'], '', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
                         $logger->info("Fork succeeded, child process, running job", [
                             'name' => $job['name'],
                             'id' => $job['jobID'],

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -186,7 +186,7 @@ try {
                         // Reset the REQUEST_ID and re-log the line so we see
                         // it when searching for either the parent and child
                         // REQUEST_IDs.
-                        $GLOBALS['REQUEST_ID'] = substr(str_replace(['+','/'], 'x', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
+                        $GLOBALS['REQUEST_ID'] = substr(str_replace(['+', '/'], 'x', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
                         $logger->info("Fork succeeded, child process, running job", [
                             'name' => $job['name'],
                             'id' => $job['jobID'],


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/50915#issuecomment-297441035

Tests:
---
First I updated my quick randotest.php file to generate old and new REQUEST_IDs, and included my filter:
```
avids-MacBook-Pro:~ dbarrett$ cat randotest.php 
<?php
// Original function
function originalGenerateID() {static $alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";mt_srand();$id = '';for ($i = 0; $i < 6; $i++) {$id .= $alphabet[mt_rand(0, strlen($alphabet) - 1)];}return $id;}

// Current function
function currentGenerateID() {
    return substr(base64_encode(sha1(strval(mt_rand()), true)), 0, 6); // random 6 character ID
}

// New function
function newGenerateID() {
    return substr(str_replace(['+','/'], '', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
}

// Output both side by side
$count = 100;
while($count--) {
    echo originalGenerateID() . "\t" . currentGenerateID() . "\t" . newGenerateID() . "\r\n";
}

Davids-MacBook-Pro:~ dbarrett$ 
```

Running it shows that the `currentGenerateID()` includes `+` and `/`, but the `newGenerateID()` does not:

```
hnA8fF	aTFBj9	aV9MqU
w2aysr	rIrOGs	xDfDUF
EvZx9n	ZUyqgC	osRSNI
qL7TUK	l4JbYj	egAoGL
UNg6wI	YgeaZ4	jmSPAS
63vV2V	/sitAv	fbHDyr
bkIzFM	gh6yUF	62HWB3
8a78zN	wZJHj+	MiRNSg
4c6a2U	UiXzcN	rvpkkp
eqAHRS	+NQfYn	QgAp61
SkIurP	zFnlYh	7sCiSY
Oj01e3	2kcrmn	bu1fzZ
ZkeBUS	pzjwg4	SCsvAH
UO1hVu	28a36w	DGIiZY
WS2r7U	2YNfwR	itHsyV
V2SLwf	Ko671E	jvs121
XZHKjA	T5eEVv	LIDmxW
YTsKUA	wctlVz	Cjy4uk
36WwaS	yIezOB	xiMwli
NgzWkH	NoxrBS	4gQrGE
koGgul	bu6EoI	Ly8kD0
aX7IyE	5Lccov	dj9TSX
0jzKKY	7ujVt9	voXGbj
z9SoGP	IximG9	iQbHtG
nUq9Pf	fZWD7S	NRQAme
4C1keS	AwadYU	6AMxA0
f6zd7A	ONWFsL	pFhSNo
0fau4t	OsSakp	UhuOT5
PfFdVW	v6Th/a	NeUIsW
vrKQtJ	h3wxmy	97YcVY
4HgDDy	TB4O+4	pbtutX
Jh8b7L	Olcwec	Jb3Lv8
a1eV94	F5KsEO	4AUtsX
JLcryA	B4b7wz	FiEmZD
LwuXry	0+T6ru	ZIiPls
pUdJna	TKOehy	Lqyg6B
jmaGXr	2MkqZ4	Q2y010
qMGzpc	ZawziJ	3DJBFu
MrY1qz	a0L8Co	KSfvuV
agiEQo	I66baG	BuV732
iWnktj	D28izB	qtAEoZ
de4fi4	nyFfeT	nLC4tK
4615JJ	OuXdiS	lxdzp1
7X37Pu	7VxNhM	woGuBU
xXP66f	H326mK	AM0U4o
EI2lZA	8NsVME	2RkG9n
EyGeb6	cYRVpT	x0JjdL
cSpcrn	JahJ1a	Os9yaw
ndXTGP	BJ2E2J	zJPQV9
EJUiwq	RIzmR3	RfuYG1
P10wcW	QVXzVb	CfohzE
hrHeeJ	u3zq6L	mNtEOO
RqLvul	TKTofR	53SFBp
IfJkqw	0z6d5f	FVBoUh
2sKLsi	+i4YjS	4NAs4q
IUd570	m45f/l	EDDglQ
9zg2Av	Zna+9/	HrhomL
G6KFSA	KChCBB	9YEIz9
YgWYzv	khvz6Z	XkbFBN
wRiVcj	pkzPKw	Ff6BTA
afQYk1	Moj3Kh	AolrMT
oCUjEy	hDeSUh	OBj2Wl
6kdmgJ	9DsOsc	r7aW1f
ZwNPxX	PJbxsq	WMtzbI
EaSRJL	qpAeIG	PWH4vp
7x6PUW	xqZxux	4OdyWy
RJwvyB	A2uPAX	FK8PIn
cvJ3kR	+2EPax	Pej57t
OWJfrm	+37a7T	kMwWfd
iVVQ3y	Ipeb9Z	OyH3C8
hUWyOA	2Q5Nn/	Wuh765
5ZtpkG	d5hNFJ	q5vdqV
aSqKtQ	QjoQ3y	rpXDoH
CBXOs1	ecMJyG	rKhKXv
6VGLth	0Nyh1g	IiypQX
d3PcEQ	GlV/kg	4SyBh7
SpDu3i	jt9/4d	tPZXsP
3N5baI	fWBHlf	UpF39h
BtLpVo	OCMbxz	w9LRPC
litzVG	EL6qHa	mwnIov
WOe6me	CcLrn1	mLZfPo
uejizn	SsYZ+4	8YYb9Z
9wm6hX	bzVC8w	QYb0PD
Hjs8vv	SvKRIM	yuYqrR
M3EEJM	uAnj6x	V2jORc
W8FMG1	S8i+M1	8YwhWV
b3HcRG	WI+xj6	eEjirF
OhgSOr	nzwi19	1xDYPr
rNdqOQ	KJlp+N	pdIsOk
OhKbN4	Z/6RkD	ycwTvN
6LBLnW	/faMZD	NeU8wk
pyRCOr	1tnTKh	YH1BnY
vRMYo3	VLMz/q	rNwAVb
pKx2GN	U7586e	9KVhcA
xZJzjT	kpEeJB	25W2Su
Bacghs	vW0etq	BDVlfJ
O5zAb2	X5UWYI	B5ofb8
AiUhYj	bt9rJE	uzLgzJ
o3bubU	hnx/Kt	KjeKdX
x4DgZl	4/Imv8	cjgScy
```

After implementing the change, I confirmed `Bedrock-PHP/sample/demo.sh` still runs, and generates good-looking REQUEST_IDs in the log.