### PR TITLE
Use idempotent parameter for CreateJob

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -135,17 +135,18 @@ class Jobs extends Plugin
      * Schedules a new job, optionally in the future, optionally to repeat.
      *
      * @param string      $name
-     * @param array|null  $data        (optional)
-     * @param string|null $firstRun    (optional)
-     * @param string|null $repeat      (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
-     * @param bool        $unique      Do we want only one job with this name to exist?
-     * @param int         $priority    (optional) Specify a job priority. Jobs with higher priorities will be run first.
-     * @param int|null    $parentJobID (optional) Specify this job's parent job.
-     * @param string      $connection  (optional) Specify 'Connection' header using constants defined in this class.
+     * @param array|null  $data         (optional)
+     * @param string|null $firstRun     (optional)
+     * @param string|null $repeat       (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param bool        $unique       Do we want only one job with this name to exist?
+     * @param int         $priority     (optional) Specify a job priority. Jobs with higher priorities will be run first.
+     * @param int|null    $parentJobID  (optional) Specify this job's parent job.
+     * @param string      $connection   (optional) Specify 'Connection' header using constants defined in this class.
+     * @param bool        $isIdempotent (optional) Whether the command can be retried if it fails.
      *
      * @return array Containing "jobID"
      */
-    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT)
+    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, $isIdempotent = false)
     {
         $this->client->getLogger()->info("Create job", ['name' => $name]);
 
@@ -160,6 +161,7 @@ class Jobs extends Plugin
                 'priority'    => $priority,
                 'parentJobID' => $parentJobID,
                 'Connection'  => $connection,
+                'idempotent'  => $isIdempotent
             ]
         );
     }

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -135,18 +135,17 @@ class Jobs extends Plugin
      * Schedules a new job, optionally in the future, optionally to repeat.
      *
      * @param string      $name
-     * @param array|null  $data         (optional)
-     * @param string|null $firstRun     (optional)
-     * @param string|null $repeat       (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
-     * @param bool        $unique       Do we want only one job with this name to exist?
-     * @param int         $priority     (optional) Specify a job priority. Jobs with higher priorities will be run first.
-     * @param int|null    $parentJobID  (optional) Specify this job's parent job.
-     * @param string      $connection   (optional) Specify 'Connection' header using constants defined in this class.
-     * @param bool        $isIdempotent (optional) Whether the command can be retried if it fails.
+     * @param array|null  $data        (optional)
+     * @param string|null $firstRun    (optional)
+     * @param string|null $repeat      (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param bool        $unique      Do we want only one job with this name to exist?
+     * @param int         $priority    (optional) Specify a job priority. Jobs with higher priorities will be run first.
+     * @param int|null    $parentJobID (optional) Specify this job's parent job.
+     * @param string      $connection  (optional) Specify 'Connection' header using constants defined in this class.
      *
      * @return array Containing "jobID"
      */
-    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, $isIdempotent = false)
+    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT)
     {
         $this->client->getLogger()->info("Create job", ['name' => $name]);
 
@@ -161,7 +160,9 @@ class Jobs extends Plugin
                 'priority'    => $priority,
                 'parentJobID' => $parentJobID,
                 'Connection'  => $connection,
-                'idempotent'  => $isIdempotent
+                // If the name of the job has to be unique, Bedrock will return any existing job that exists with the
+                // given name instead of making a new one, which essentially makes the command idempotent.
+                'idempotent'  => $unique
             ]
         );
     }


### PR DESCRIPTION
@iwiznia please review

When calling `CreateJob`, set `idempotent` based on `$unique`. This will allow any request that failed due a `ConnectionFailure` to be automatically retried if `$unique = true`.
Given that when creating jobs with `$unique = true`, Bedrock returns data about any existing job with the same name if it exists, there's no risk to accidentally create another job with the same name.