### PR TITLE
Append a semicolon to queries if none exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.16",
+    "version": "1.0.17",
     "authors": [
         {
             "name": "Expensify",

--- a/src/DB.php
+++ b/src/DB.php
@@ -39,6 +39,7 @@ class DB extends Plugin
      */
     public function query($sql)
     {
+        $sql = substr($sql, -1) === ";" ? $sql : $sql.";";
         $response = new Response($this->client->call(
             "Query",
             [


### PR DESCRIPTION
cc @cead22 
Let's append `;` to a query if it does not exist

This is needed for https://github.com/Expensify/Bedrock/pull/215
