### PR TITLE
Temporary BWM load handler

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -29,14 +29,14 @@ if (php_sapi_name() !== "cli") {
 }
 
 // Parse the command line and verify the required settings are provided
-$options = getopt('', ['host::', 'port::', 'failoverHost::', 'failoverPort::', 'maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 'stats::', 'workerPath::', 'versionWatchFile::', 'writeConsistency::', ‘maxNumberWorkerThreads::’]);
+$options = getopt('', ['host::', 'port::', 'failoverHost::', 'failoverPort::', 'maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 'stats::', 'workerPath::', 'versionWatchFile::', 'writeConsistency::', 'maxNumberWorkerThreads::']);
 
 // Store parent ID to determine if we should continue forking
 $parentID = getmypid();
 
 $workerPath = @$options['workerPath'];
 if (!$workerPath) {
-    echo "Usage: sudo -u user php ./bin/BedrockWorkerManager.php --workerPath=<workerPath> [--jobName=<jobName> --maxLoad=<maxLoad> --host=<host> --port=<port> --maxIterations=<iteration> --writeConsistency=<consistency>]\r\n";
+    echo "Usage: sudo -u user php ./bin/BedrockWorkerManager.php --workerPath=<workerPath> [--jobName=<jobName> --maxLoad=<maxLoad> --host=<host> --port=<port> --maxIterations=<iteration> --writeConsistency=<consistency> --maxNumberWorkerThreads=<maxNumberWorkerThreads>]\r\n";
     exit(1);
 }
 
@@ -44,7 +44,7 @@ if (!$workerPath) {
 $jobName = $options['jobName'] ?? '*'; // Process all jobs by default
 $maxLoad = floatval(@$options['maxLoad']) ?: 1.0; // Max load of 1.0 by default
 $maxIterations = intval(@$options['maxIterations']) ?: -1; // Unlimited iterations by default
-$maxNumberWorkerThreads = intval($options[‘maxNumberWorkerThreads’]) ?? 5; // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
+$maxNumberWorkerThreads = intval($options['maxNumberWorkerThreads']) ?? 5; // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
 
 // Configure the Bedrock client with these command-line options
 Client::configure($options);
@@ -100,10 +100,10 @@ try {
             // Check if we can fork based on the load of our webservers
             $load = sys_getloadavg()[0];
             if ($load < $maxLoad || count($output) < $maxNumberWorkerThreads) {
-                $logger->info('Load is under max, checking for more work.', ['load' => $load, 'MAX_LOAD' => $maxLoad]);
+                $logger->info('Load is under max, checking for more work.', ['load' => $load, 'MAX_LOAD' => $maxLoad, 'numberWorkerThreads' => count($output), 'forkIterations' => $forkIterations]);
                 break;
             } else {
-                $logger->info('Load is over max, waiting 1s and trying again.', ['load' => $load, 'MAX_LOAD' => $maxLoad, 'forkIterations' => $forkIterations]);
+                $logger->info('Load is over max, waiting 1s and trying again.', ['load' => $load, 'MAX_LOAD' => $maxLoad, 'numberWorkerThreads' => count($output), 'forkIterations' => $forkIterations]);
                 sleep(1);
             }
         }

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -99,7 +99,7 @@ try {
 
             // Check if we can fork based on the load of our webservers
             $load = sys_getloadavg()[0];
-            if ($load < $maxLoad || count($output) < $maxNumberWorkerThreads) {
+            if ($load < $maxLoad && count($output) < $maxNumberWorkerThreads) {
                 $logger->info('Load is under max, checking for more work.', ['load' => $load, 'MAX_LOAD' => $maxLoad, 'numberWorkerThreads' => count($output), 'forkIterations' => $forkIterations]);
                 break;
             } else {

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -29,7 +29,11 @@ if (php_sapi_name() !== "cli") {
 }
 
 // Parse the command line and verify the required settings are provided
-$options = getopt('', ['host::', 'port::', 'failoverHost::', 'failoverPort::', 'maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 'stats::', 'workerPath::', 'versionWatchFile::', 'writeConsistency::']);
+$options = getopt('', ['host::', 'port::', 'failoverHost::', 'failoverPort::', 'maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 'stats::', 'workerPath::', 'versionWatchFile::', 'writeConsistency::', ‘maxNumberWorkerThreads::’]);
+
+// Store parent ID to determine if we should continue forking
+$parentID = getmypid();
+
 $workerPath = @$options['workerPath'];
 if (!$workerPath) {
     echo "Usage: sudo -u user php ./bin/BedrockWorkerManager.php --workerPath=<workerPath> [--jobName=<jobName> --maxLoad=<maxLoad> --host=<host> --port=<port> --maxIterations=<iteration> --writeConsistency=<consistency>]\r\n";
@@ -40,6 +44,7 @@ if (!$workerPath) {
 $jobName = $options['jobName'] ?? '*'; // Process all jobs by default
 $maxLoad = floatval(@$options['maxLoad']) ?: 1.0; // Max load of 1.0 by default
 $maxIterations = intval(@$options['maxIterations']) ?: -1; // Unlimited iterations by default
+$maxNumberWorkerThreads = intval($options[‘maxNumberWorkerThreads’]) ?? 5; // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
 
 // Configure the Bedrock client with these command-line options
 Client::configure($options);
@@ -81,18 +86,24 @@ try {
         $iteration++;
         $logger->info("Loop iteration", ['iteration' => $iteration]);
 
+        $forkIterations = 0;
         // Step One wait for resources to free up
         while (true) {
             // Get the latest load
             if (!file_exists('/proc/loadavg')) {
                 throw new Exception('are you in a chroot?  If so, please make sure /proc is mounted correctly');
             }
+
+            // Check if we can fork based on our hard-coded limit
+            exec("pgrep -P $parentID", $output);
+
+            // Check if we can fork based on the load of our webservers
             $load = sys_getloadavg()[0];
-            if ($load < $maxLoad) {
+            if ($load < $maxLoad || count($output) < $maxNumberWorkerThreads) {
                 $logger->info('Load is under max, checking for more work.', ['load' => $load, 'MAX_LOAD' => $maxLoad]);
                 break;
             } else {
-                $logger->info('Load is over max, waiting 1s and trying again.', ['load' => $load, 'MAX_LOAD' => $maxLoad]);
+                $logger->info('Load is over max, waiting 1s and trying again.', ['load' => $load, 'MAX_LOAD' => $maxLoad, 'forkIterations' => $forkIterations]);
                 sleep(1);
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.16",
+    "version": "1.0.18",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
**Problem**
BWM-PHP kicks off multiple forks of itself to connect to bedrock to query for work (the query itself is blocking - when BWM has a job ready, it’ll then respond to the request).
 
We have a substantial amount of jobs that are queued to be worked on, and they cannot all kick off at once or else we will effectively DDOS ourselves.

**Solution**
Use a command-line argument that caps the number of forks that can exist at any moment to a configurable number.

**Tests**
1. Create 10 jobs with a 5 second sleep.
2. Run bwm with `--maxNumberWorkerThreads=1`
3. Tail logs, confirm number of worker threads is never above 1.
4. Repeat steps 1-3 with `--maxNumberWorkerThreads=5`.