### PR TITLE
Use intval after the null coalescing operator so the default can be properly set

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -42,8 +42,8 @@ if (!$workerPath) {
 
 // Add defaults
 $jobName = $options['jobName'] ?? '*'; // Process all jobs by default
-$maxLoad = floatval(@$options['maxLoad']) ?: 1.0; // Max load of 1.0 by default
-$maxIterations = intval(@$options['maxIterations']) ?: -1; // Unlimited iterations by default
+$maxLoad = floatval($options['maxLoad'] ?? 1.0); // Max load of 1.0 by default
+$maxIterations = intval($options['maxIterations'] ?? -1); // Unlimited iterations by default
 $maxNumberWorkerThreads = intval($options['maxNumberWorkerThreads'] ?? 5); // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
 
 // Configure the Bedrock client with these command-line options

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -44,7 +44,7 @@ if (!$workerPath) {
 $jobName = $options['jobName'] ?? '*'; // Process all jobs by default
 $maxLoad = floatval(@$options['maxLoad']) ?: 1.0; // Max load of 1.0 by default
 $maxIterations = intval(@$options['maxIterations']) ?: -1; // Unlimited iterations by default
-$maxNumberWorkerThreads = intval($options['maxNumberWorkerThreads']) ?? 5; // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
+$maxNumberWorkerThreads = intval($options['maxNumberWorkerThreads'] ?? 5); // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
 
 // Configure the Bedrock client with these command-line options
 Client::configure($options);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.18",
+    "version": "1.0.19",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
The `intval` call was preventing the null coalescing operator from properly setting the default value

![image](https://user-images.githubusercontent.com/3620873/27243823-a446ef24-5298-11e7-849e-bc8318d10dc9.png)

# Tests
1. Create 10 jobs with a 5 second sleep.
1. Run bwm with --maxNumberWorkerThreads=4
    - Tail logs, confirm number of worker threads is never above 4 (search for `Load is`) and there are no notices referencing `maxNumberWorkerThreads`
1. Repeat steps 1-2 without a default
    - Tail logs, confirm that the number of worker threads is never over the default (5) and there are no notices referencing `maxNumberWorkerThreads`