### PR TITLE
Including silencing operator so that bwm script continues working without argument

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -44,7 +44,7 @@ if (!$workerPath) {
 $jobName = $options['jobName'] ?? '*'; // Process all jobs by default
 $maxLoad = floatval(@$options['maxLoad']) ?: 1.0; // Max load of 1.0 by default
 $maxIterations = intval(@$options['maxIterations']) ?: -1; // Unlimited iterations by default
-$maxNumberWorkerThreads = intval($options['maxNumberWorkerThreads']) ?? 5; // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
+$maxNumberWorkerThreads = intval(@$options['maxNumberWorkerThreads']) ?? 5; // Max number of worker threads for temporary load handling. TODO: Remove this in favor of better solution
 
 // Configure the Bedrock client with these command-line options
 Client::configure($options);


### PR DESCRIPTION
Problem:
Running `bwm.sh` locally would fail, giving us this,
`Jun 16 19:41:31 vagrant-ubuntu-trusty-64 php: COHiHd vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [dbug] PHP Notice: Undefined index: maxNumberWorkerThreads - 9d25b0de8c3a4f169bf378d394692cc4 ~~ exceptionLine: '47' exceptionFile: '/vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php'`

Solution:
Two ways to solve this,
 - adding error control operator here, or,
 - including argument in bwm.script

Felt like it was better to add it here so i did. Do let me know if otherwise.

In reference to [comment](https://github.com/Expensify/Bedrock-PHP/pull/23#pullrequestreview-44654656)

Tests:
Same as [PR](https://github.com/Expensify/Bedrock-PHP/pull/23) and ensure that nothing got broken.