### PR TITLE
Log full response body when length differs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.25",
+    "version": "1.0.26",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -446,9 +446,11 @@ class Client implements LoggerAwareInterface
             $rawResponseBody .= $this->recv();
         }
         if (strlen($rawResponseBody) != $contentLength) {
-            $this->getLogger()->warning('Server sent more content than expected, ignoring.',
-                ['Content-Length' => $contentLength, 'bodyLength' => strlen($rawResponseBody)]
-            );
+            $this->getLogger()->warning('Server sent more content than expected, ignoring.', [
+                'Content-Length' => $contentLength,
+                'bodyLength' => strlen($rawResponseBody),
+                'response' => $rawResponseBody,
+            ]);
         }
 
         // If there is a body, let's parse it


### PR DESCRIPTION
@flodnv please review. /cc @tylerkaraszewski 

Related to https://github.com/Expensify/Expensify/issues/59222#issuecomment-320674382

Add more logs to find out what happens when bedrock returns an invalid response.