### PR TITLE
Add enableLoadHandler to inner function

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -233,7 +233,7 @@ try {
                     // that we automatically pick up new versions over the
                     // worker without needing to restart the parent.
                     include_once $workerFilename;
-                    $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrock, $jobs, $job, $extraParams, $logger, $localDB) {
+                    $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrock, $jobs, $job, $extraParams, $logger, $localDB, $enableLoadHandler) {
                         $worker = new $workerName($bedrock, $job);
                         $childPID = getmypid();
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Another hotfix for bedrock worker manager.

# Tests
1. Queue a bunch of jobs
2. Tail logs and grep "numActive"
3. run BedrockWorkerManager with `--enableLoadHandler` flag
4. Confirm in the logs that numActive fluctuates.