### PR TITLE
Add potential performance improvements for BWM load handler

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -64,7 +64,7 @@ if ($enableLoadHandler) {
         started text NOT NULL,
         ended text
     );
-    CREATE INDEX IF NOT EXISTS idx ON localJobs (localJobID);
+    CREATE INDEX IF NOT EXISTS localJobsLocalJobID ON localJobs (localJobID);
     PRAGMA journal_mode = WAL;';
     $localDB->write($query);
 }

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -53,10 +53,9 @@ $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD l
 $target = $minSafeJobs;
 
 // Set up the database for the AIMD load handler.
-$localDB = new LocalDB($pathToDB);
-$localDB->open();
-
 if ($enableLoadHandler) {
+    $localDB = new LocalDB($pathToDB);
+    $localDB->open();
     $query = 'CREATE TABLE IF NOT EXISTS localJobs (
         localJobID integer PRIMARY KEY AUTOINCREMENT NOT NULL,
         pid integer NOT NULL,
@@ -64,7 +63,9 @@ if ($enableLoadHandler) {
         jobName text NOT NULL,
         started text NOT NULL,
         ended text
-    );';
+    );
+    CREATE INDEX IF NOT EXISTS idx ON localJobs (localJobID);
+    PRAGMA journal_mode = WAL;';
     $localDB->write($query);
 }
 
@@ -202,7 +203,9 @@ try {
                 ]);
 
                 // Close DB connection before forking.
-                $localDB->close();
+                if ($enableLoadHandler) {
+                    $localDB->close();
+                }
                 pcntl_signal(SIGCHLD, SIG_IGN);
                 $pid = pcntl_fork();
                 if ($pid == -1) {
@@ -283,7 +286,9 @@ try {
                     exit(1);
                 } else {
                     // Reopen the DB connection in the parent thread.
-                    $localDB->open();
+                    if ($enableLoadHandler) {
+                        $localDB->open();
+                    }
 
                     // Otherwise we are the parent thread -- continue execution
                     $logger->info("Successfully ran job", [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.27",
+    "version": "1.0.28",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
This PR introduces a few potential performance improvements for the BWM load handler.

1. Only open/close the connection if the load handler is enabled.
2. Enable WAL mode on the database. This is persistent so should only have to happen on DB creation.
3. Create an index on the `localJobID` if one doesn't exist already.

# Tests
1. Delete localJobsDB.sql if it exists.
2. Queue test jobs
3. Run BWM with load handler enabled.
4. Confirm that there are no errors.
5. Open up `/tmp/localJobsDB.sql` and run `PRAGMA journal_mode;` and confirm the output is `wal`.
6. Run `.schema localJobs` and confirm the output is
```
CREATE TABLE localJobs (
        localJobID integer PRIMARY KEY AUTOINCREMENT NOT NULL,
        pid integer NOT NULL,
        jobID integer NOT NULL,
        jobName text NOT NULL,
        started text NOT NULL,
        ended text
    );
CREATE INDEX idx ON localJobs (localJobID);
```

**Please** review/approve it then let me package it before merging.