### PR TITLE
Move creation of localDB object out of if statement to satisfy strict typing

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -51,10 +51,10 @@ $maxSafeTime = intval($options['maxSafeTime'] ?? 0); // The maximum job time bef
 $debugThrottle = isset($options['debugThrottle']); // Set to true to maintain a debug history
 $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD load handler
 $target = $minSafeJobs;
+$localDB = new LocalDB($pathToDB);
 
 // Set up the database for the AIMD load handler.
 if ($enableLoadHandler) {
-    $localDB = new LocalDB($pathToDB);
     $localDB->open();
     $query = 'CREATE TABLE IF NOT EXISTS localJobs (
         localJobID integer PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.28",
+    "version": "1.0.29",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Due to poor testing on my part, this snuck through and was crashing BWM when the load handler wasn't enabled. This just makes sure the localDB object is defined.

Fixes https://github.com/Expensify/Expensify/issues/59896

# Tests
1. Delete localJobsDB.sql if it exists.
2. Queue test jobs
3. Run BWM with load handler enabled.
4. Confirm that there are no errors.
5. Open up `/tmp/localJobsDB.sql` and run `PRAGMA journal_mode;` and confirm the output is `wal`.
6. Run `.schema localJobs` and confirm the output is
```
CREATE TABLE localJobs (
        localJobID integer PRIMARY KEY AUTOINCREMENT NOT NULL,
        pid integer NOT NULL,
        jobID integer NOT NULL,
        jobName text NOT NULL,
        started text NOT NULL,
        ended text
    );
CREATE INDEX idx ON localJobs (localJobID);
```

1. Queue test jobs
2. Run BWM with load handler disabled
3. Confirm there are no errors and jobs are queued and run.

**Please** review/approve it then let me package it before merging.