### PR TITLE
Catch localJobsDB sqlite exception and retry immediately

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -51,9 +51,16 @@ $maxSafeTime = intval($options['maxSafeTime'] ?? 0); // The maximum job time bef
 $debugThrottle = isset($options['debugThrottle']); // Set to true to maintain a debug history
 $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD load handler
 $target = $minSafeJobs;
-$localDB = new LocalDB($pathToDB);
+
+// Configure the Bedrock client with these command-line options
+Client::configure($options);
+
+// Prepare to use the host logger, if configured
+$logger = Client::getLogger();
+$logger->info('Starting BedrockWorkerManager', ['maxIterations' => $maxIterations]);
 
 // Set up the database for the AIMD load handler.
+$localDB = new LocalDB($pathToDB, $logger);
 if ($enableLoadHandler) {
     $localDB->open();
     $query = 'CREATE TABLE IF NOT EXISTS localJobs (
@@ -68,13 +75,6 @@ if ($enableLoadHandler) {
     PRAGMA journal_mode = WAL;';
     $localDB->write($query);
 }
-
-// Configure the Bedrock client with these command-line options
-Client::configure($options);
-
-// Prepare to use the host logger, if configured
-$logger = Client::getLogger();
-$logger->info('Starting BedrockWorkerManager', ['maxIterations' => $maxIterations]);
 
 // If --versionWatch is enabled, begin watching a version file for changes
 $versionWatchFile = @$options['versionWatchFile'];

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.31",
+    "version": "1.0.32",
     "authors": [
         {
             "name": "Expensify",

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -66,7 +66,12 @@ class LocalDB
                 $result = $this->handle->query($query);
                 break;
             } catch (Exception $e) {
-                $this->logger->info("Query failed, retrying", ['query' => $query, 'error' => json_encode($e)]);
+                if ($e->getMessage() === 'database is locked') {
+                    $this->logger->info("Query failed, retrying", ['query' => $query, 'error' => $e->getMessage()]);
+                } else {
+                    $this->logger->info("Query failed, not retrying", ['query' => $query, 'error' => $e->getMessage()]);
+                    throw $e;
+                }
             }
         }
 
@@ -87,7 +92,12 @@ class LocalDB
                 $this->handle->query($query);
                 break;
             } catch (Exception $e) {
-                $this->logger->info("Query failed, retrying", ['query' => $query, 'error' => json_encode($e)]);
+                if ($e->getMessage() === 'database is locked') {
+                    $this->logger->info("Query failed, retrying", ['query' => $query, 'error' => $e->getMessage()]);
+                } else {
+                    $this->logger->info("Query failed, not retrying", ['query' => $query, 'error' => $e->getMessage()]);
+                    throw $e;
+                }
             }
         }
     }

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Expensify\Bedrock;
 
+use Exception;
+use Psr\Log\LoggerInterface;
 use SQLite3;
 
 /**
@@ -17,12 +19,16 @@ class LocalDB
     /** @var string $location */
     private $location;
 
+    /** @var LoggerInterface $logger */
+    private $logger;
+
     /**
      * Creates a localDB object and sets the file location.
      */
-    public function __construct(string $location)
+    public function __construct(string $location, LoggerInterface $logger)
     {
         $this->location = $location;
+        $this->logger = $logger;
     }
 
     /**
@@ -32,6 +38,7 @@ class LocalDB
         if (!isset($this->handle)) {
             $this->handle = new SQLite3($this->location);
             $this->handle->busyTimeout(15000);
+            $this->handle->enableExceptions(true);
         }
     }
 
@@ -53,7 +60,15 @@ class LocalDB
      */
     public function read(string $query)
     {
-        $result = $this->handle->query($query);
+        $result = null;
+        while(true) {
+            try {
+                $result = $this->handle->query($query);
+                break;
+            } catch (Exception $e) {
+                $this->logger->info("Query failed, retrying", ['query' => $query, 'error' => json_encode($e)]);
+            }
+        }
 
         if ($result) {
             $returnValue = $result->fetchArray(SQLITE3_NUM);
@@ -67,7 +82,14 @@ class LocalDB
      */
     public function write(string $query)
     {
-        $this->handle->query($query);
+        while(true) {
+            try {
+                $this->handle->query($query);
+                break;
+            } catch (Exception $e) {
+                $this->logger->info("Query failed, retrying", ['query' => $query, 'error' => json_encode($e)]);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
The local SQLite DB is having locking issues so when it runs into an error we'll log the error and retry.

Related to https://github.com/Expensify/Expensify/issues/60379#issuecomment-325038663

# Tests
1. Queue a million jobs
2. Run bwm with enableLoadHandler
3. Wait forever
4. `grep 'database is locked' syslog` and confirm that it doesn't appear
5. `grep 'Query failed, retrying' syslog` and confirm that it does appear
6. Run bwm without enableLoadHandler
7. Confirm everything runs with no errors.