### PR TITLE
Add options to change name and nextRun in retryJob

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -264,7 +264,7 @@ try {
                                 'id' => $job['jobID'],
                                 'extraParams' => $extraParams,
                             ]);
-                            $jobs->retryJob($job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
+                            $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
                         } catch (Throwable $e) {
                             $logger->alert("Job failed with errors, exiting.", [
                                 'name' => $job['name'],

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -264,7 +264,7 @@ try {
                                 'id' => $job['jobID'],
                                 'extraParams' => $extraParams,
                             ]);
-                            $jobs->retryJob($job['jobID'], $e->getDelay(), $worker->getData());
+                            $jobs->retryJob($job['jobID'], $e->getDelay(), $worker->getData(), $e->getNextRun(), $e->getName());
                         } catch (Throwable $e) {
                             $logger->alert("Job failed with errors, exiting.", [
                                 'name' => $job['name'],

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -264,7 +264,7 @@ try {
                                 'id' => $job['jobID'],
                                 'extraParams' => $extraParams,
                             ]);
-                            $jobs->retryJob($job['jobID'], $e->getDelay(), $worker->getData(), $e->getNextRun(), $e->getName());
+                            $jobs->retryJob($job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
                         } catch (Throwable $e) {
                             $logger->alert("Job failed with errors, exiting.", [
                                 'name' => $job['name'],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.32",
+    "version": "1.0.34",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -180,7 +180,7 @@ class Client implements LoggerAwareInterface
                 // conditions.
                 $this->sendRawRequest($rawRequest);
                 $response = $this->receiveRawResponse();
-                
+
                 // Record the last error in the response as this affects how we
                 // handle errors on this command
                 if ($lastTryException) {

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -32,10 +32,10 @@ class RetryableException extends BedrockError
      * @param ?int        $delay    Time (in seconds)  to delay the retry.
      * @param int        $code     Code of the exception
      * @param ?Exception $previous
-     * @param string     $name     New name for the job
-     * @param string     $nextRun  DateTime to retry the job
+     * @param ?string    $name     New name for the job
+     * @param ?string    $nextRun  DateTime to retry the job
      */
-    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name, string $nextRun = '')
+    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name = null, string $nextRun = null)
     {
         $code = $code ?? 666;
         $this->delay = $delay;

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -32,10 +32,10 @@ class RetryableException extends BedrockError
      * @param ?int        $delay    Time (in seconds)  to delay the retry.
      * @param int        $code     Code of the exception
      * @param ?Exception $previous
-     * @param ?string    $name     New name for the job
-     * @param ?string    $nextRun  DateTime to retry the job
+     * @param string     $name     New name for the job
+     * @param string     $nextRun  DateTime to retry the job
      */
-    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name = null, string $nextRun = null)
+    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name, string $nextRun = '')
     {
         $code = $code ?? 666;
         $this->delay = $delay;

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -16,16 +16,31 @@ class RetryableException extends BedrockError
     private $delay;
 
     /**
+     * @var string DateTime to retry this job
+     */
+    private $nextRun;
+
+    /**
+     * @var string New name for the job
+     */
+    private $name;
+
+    /**
      * RetryableException constructor.
      *
      * @param string         $message  Message of the exception
      * @param int            $delay    Time (in seconds)  to delay the retry.
      * @param int            $code     Code of the exception
      * @param Exception|null $previous
+     * @param string         $nextRun  DateTime to retry the job
+     * @param string         $name     New name for the job
      */
-    public function __construct($message, $delay = 0, $code = 666, Exception $previous = null)
+    public function __construct($message, $delay = 0, $code = null, Exception $previous = '', $nextRun = '')
     {
+        $code = $code ?? 666;
         $this->delay = $delay;
+        $this->nextRun = $nextRun;
+        $this->name = $name;
         parent::__construct($message, $code, $previous);
     }
 
@@ -37,5 +52,25 @@ class RetryableException extends BedrockError
     public function getDelay()
     {
         return $this->delay;
+    }
+
+    /**
+     * Returns the nextRun time.
+     *
+     * @return string
+     */
+    public function getNextRun()
+    {
+        return $this->nextRun;
+    }
+
+    /**
+     * Returns the new name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
     }
 }

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -28,14 +28,14 @@ class RetryableException extends BedrockError
     /**
      * RetryableException constructor.
      *
-     * @param string         $message  Message of the exception
-     * @param int            $delay    Time (in seconds)  to delay the retry.
-     * @param int            $code     Code of the exception
-     * @param Exception|null $previous
-     * @param string         $nextRun  DateTime to retry the job
-     * @param string         $name     New name for the job
+     * @param string     $message  Message of the exception
+     * @param ?int        $delay    Time (in seconds)  to delay the retry.
+     * @param int        $code     Code of the exception
+     * @param ?Exception $previous
+     * @param string     $name     New name for the job
+     * @param string     $nextRun  DateTime to retry the job
      */
-    public function __construct($message, $delay = 0, $code = null, Exception $previous = '', $nextRun = '')
+    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name, string $nextRun = '')
     {
         $code = $code ?? 666;
         $this->delay = $delay;

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -11,12 +11,12 @@ use Expensify\Bedrock\Exceptions\BedrockError;
 class RetryableException extends BedrockError
 {
     /**
-     * @var int Time (in seconds) to delay the retry.
+     * @var int Time to delay the retry (in seconds)
      */
     private $delay;
 
     /**
-     * @var string DateTime to retry this job
+     * @var string When to retry the job (takes precedence over delay; expects format Y-m-d H:i:s)
      */
     private $nextRun;
 
@@ -29,13 +29,13 @@ class RetryableException extends BedrockError
      * RetryableException constructor.
      *
      * @param string     $message  Message of the exception
-     * @param ?int        $delay    Time (in seconds)  to delay the retry.
-     * @param int        $code     Code of the exception
+     * @param ?int       $delay    Time to delay the retry (in seconds)
+     * @param ?int       $code     Code of the exception
      * @param ?Exception $previous
-     * @param string     $name     New name for the job
-     * @param string     $nextRun  DateTime to retry the job
+     * @param ?string    $name     New name for the job
+     * @param ?string    $nextRun  When to retry the job (takes precedence over delay; expects format Y-m-d H:i:s)
      */
-    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name = '', string $nextRun = '')
+    public function __construct(string $message, int $delay = 0, int $code = null, Exception $previous = null, string $name = '', string $nextRun = '')
     {
         $code = $code ?? 666;
         $this->delay = $delay;
@@ -45,17 +45,15 @@ class RetryableException extends BedrockError
     }
 
     /**
-     * Returns the time to delay the retry (in seconds).
-     *
-     * @return int
+     * Returns the time to delay the retry (in seconds)
      */
-    public function getDelay()
+    public function getDelay(): int
     {
         return $this->delay;
     }
 
     /**
-     * Returns the nextRun time.
+     * Returns the nextRun time
      */
     public function getNextRun(): string
     {
@@ -63,7 +61,7 @@ class RetryableException extends BedrockError
     }
 
     /**
-     * Returns the new name.
+     * Returns the new name
      */
     public function getName(): string
     {

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -35,7 +35,7 @@ class RetryableException extends BedrockError
      * @param string     $name     New name for the job
      * @param string     $nextRun  DateTime to retry the job
      */
-    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name, string $nextRun = '')
+    public function __construct($message, $delay = 0, $code = null, Exception $previous = null, string $name = '', string $nextRun = '')
     {
         $code = $code ?? 666;
         $this->delay = $delay;

--- a/src/Exceptions/Jobs/RetryableException.php
+++ b/src/Exceptions/Jobs/RetryableException.php
@@ -29,7 +29,7 @@ class RetryableException extends BedrockError
      * RetryableException constructor.
      *
      * @param string     $message  Message of the exception
-     * @param ?int       $delay    Time to delay the retry (in seconds)
+     * @param ?int       $delay    Time to delay the retry (in seconds; maximum value is currently 999)
      * @param ?int       $code     Code of the exception
      * @param ?Exception $previous
      * @param ?string    $name     New name for the job

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -346,13 +346,15 @@ class Jobs extends Plugin
     /**
      * Retry a job. Job must be in a RUNNING state to be able to be retried.
      *
-     * @param int   $jobID
-     * @param int   $delay
-     * @param array $data
+     * @param int    $jobID
+     * @param int    $delay
+     * @param array  $data
+     * @param string $name
+     * @param string $nextRun
      *
      * @return array
      */
-    public function retryJob($jobID, $delay = 0, $data = [])
+    public function retryJob($jobID, $delay = 0, $data = [], $name = '', $nextRun = '')
     {
         return $this->call(
             "RetryJob",
@@ -360,6 +362,8 @@ class Jobs extends Plugin
                 "jobID"      => $jobID,
                 "delay"      => $delay,
                 "data"       => $data,
+                "name"       => $name,
+                "nextRun"    => $nextRun,
                 "idempotent" => true,
             ]
         );

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -345,14 +345,8 @@ class Jobs extends Plugin
 
     /**
      * Retry a job. Job must be in a RUNNING state to be able to be retried.
-     *
-     * @param int     $jobID
-     * @param int     $delay
-     * @param ?array  $data
-     *
-     * @return array
      */
-    public function retryJob($jobID, $delay = 0, $data = null, string $name = '', string $nextRun = '')
+    public function retryJob(int $jobID, int $delay = 0, array $data = null, string $name = '', string $nextRun = ''): array
     {
         return $this->call(
             "RetryJob",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -346,15 +346,15 @@ class Jobs extends Plugin
     /**
      * Retry a job. Job must be in a RUNNING state to be able to be retried.
      *
-     * @param int    $jobID
-     * @param int    $delay
-     * @param array  $data
-     * @param string $name
-     * @param string $nextRun
+     * @param int     $jobID
+     * @param int     $delay
+     * @param ?array  $data
+     * @param string  $name
+     * @param string  $nextRun
      *
      * @return array
      */
-    public function retryJob($jobID, $delay = 0, $data = [], $name = '', $nextRun = '')
+    public function retryJob($jobID, $delay = 0, $data = null, $name = '', $nextRun = '')
     {
         return $this->call(
             "RetryJob",


### PR DESCRIPTION
Giving this to Chirag to complete over the next few days since I'll be out.

I hate that the order of parameters for `RetryableException` doesn't make any sense, but I don't want to change it so we can be backwards compatible.  
We can create another exception type so the that order of parameters makes more sense, but that doesn't seem worth it.

I didn't update the package version yet, I'll wait for the review before doing that

Closes https://github.com/Expensify/Expensify/issues/59735

## Tests
- Create a job, retry it with changing it's name, confirm the name was changed
```
>>> use Expensify\Bedrock\Client;use Expensify\Bedrock\DB;use Expensify\Bedrock\Jobs;$c = new Client(); $jobs = new Jobs($c);$db = new DB($c)
=> Expensify\Bedrock\DB {#395}
>>> $jobs->createJob('foo')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10312",
       "nodeName" => "bedrock",
       "peekTime" => "70",
       "processTime" => "9770",
       "totalTime" => "26502",
       "Content-Length" => "14",
     ],
     "rawBody" => "{"jobID":2440}",
     "body" => [
       "jobID" => 2440,
     ],
   ]
>>> $j = $jobs->getJob('foo')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10313",
       "nodeName" => "bedrock",
       "peekTime" => "4558",
       "processTime" => "2143",
       "totalTime" => "15718",
       "Content-Length" => "37",
     ],
     "rawBody" => "{"data":[],"jobID":2439,"name":"foo"}",
     "body" => [
       "data" => [],
       "jobID" => 2439,
       "name" => "foo",
     ],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-19 21:46:18",2439,"RUNNING","foo","2017-09-19 21:49:19","2017-09-19 22:09:16","",[],500,0,""]]}"
>>> $jobs->retryJob($j['body']['jobID'], 0, $j['body']['data'], 'foo?bar')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10314",
       "nodeName" => "bedrock",
       "peekTime" => "55",
       "processTime" => "2168",
       "totalTime" => "6109",
       "Content-Length" => "0",
     ],
     "rawBody" => "",
     "body" => [],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-19 21:46:18",2439,"QUEUED","foo?bar","2017-09-19 22:09:54","2017-09-19 22:09:16","",[],500,0,""]]}"
```
- Get the previous job, retry it with changing it's name and the nextRun time, confirm the name and nextRun were changed
```
>>> $j = $jobs->getJob('foo?bar')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10369",
       "nodeName" => "bedrock",
       "peekTime" => "2719",
       "processTime" => "1173",
       "totalTime" => "9072",
       "Content-Length" => "41",
     ],
     "rawBody" => "{"data":[],"jobID":2444,"name":"foo?bar"}",
     "body" => [
       "data" => [],
       "jobID" => 2444,
       "name" => "foo?bar",
     ],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-19 22:08:04",2440,"RUNNING","foo","2017-09-19 22:08:04","2017-09-19 23:29:38","",{},500,0,""]]}"
>>> $jobs->retryJob($j['body']['jobID'], 0, $j['body']['data'], 'foo?bar=baz', '2017-09-23 22:08:04')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10317",
       "nodeName" => "bedrock",
       "peekTime" => "44",
       "processTime" => "1912",
       "totalTime" => "10998",
       "Content-Length" => "0",
     ],
     "rawBody" => "",
     "body" => [],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-19 22:08:04",2440,"QUEUED","foo?bar=baz","2017-09-23 22:08:04","2017-09-19 23:29:38","",[],500,0,""]]}"
```
- Create a job, throw a RetryableException, confirm that the name and nextRun time are changed
```
>>> use Expensify\Bedrock\Exceptions\Jobs\RetryableException;
>>> $jobs->createJob('baz')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10318",
       "nodeName" => "bedrock",
       "peekTime" => "61",
       "processTime" => "1430",
       "totalTime" => "5477",
       "Content-Length" => "14",
     ],
     "rawBody" => "{"jobID":2442}",
     "body" => [
       "jobID" => 2442,
     ],
   ]
>>> $j = $jobs->getJob('baz')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10319",
       "nodeName" => "bedrock",
       "peekTime" => "3783",
       "processTime" => "2229",
       "totalTime" => "10588",
       "Content-Length" => "37",
     ],
     "rawBody" => "{"data":{},"jobID":2442,"name":"baz"}",
     "body" => [
       "data" => [],
       "jobID" => 2442,
       "name" => "baz",
     ],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-19 23:33:19",2442,"RUNNING","baz","2017-09-19 23:33:19","2017-09-19 23:33:28","",{},500,0,""]]}"
>>> $e = new RetryableException('retrying this jawn', 0, null, null, 'baz?bar', '2017-09-23 22:08:04')
=> Expensify\Bedrock\Exceptions\Jobs\RetryableException {#386
     #message: "retrying this jawn",
     #code: 666,
     #file: "/home/vagrant/.config/composer/vendor/psy/psysh/src/Psy/ExecutionLoop/Loop.php(90) : eval()'d code",
     #line: 1,
   }
>>> $jobs->retryJob($j['body']['jobID'], $e->getDelay(), $j['body']['data'], $e->getName(), $e->getNextRun())
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10323",
       "nodeName" => "bedrock",
       "peekTime" => "47",
       "processTime" => "5983",
       "totalTime" => "14693",
       "Content-Length" => "0",
     ],
     "rawBody" => "",
     "body" => [],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-19 23:37:37",2443,"QUEUED","baz?bar","2017-09-23 22:08:04","2017-09-19 23:37:46","",[],500,0,""]]}"
```
- Create a job, test that `RetryableException` with `delay` still works
```
>>> $jobs->createJob('bar')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10374",
       "nodeName" => "bedrock",
       "peekTime" => "59",
       "processTime" => "792",
       "totalTime" => "8992",
       "Content-Length" => "14",
     ],
     "rawBody" => "{"jobID":2446}",
     "body" => [
       "jobID" => 2446,
     ],
   ]
>>> $j = $jobs->getJob('bar')
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10375",
       "nodeName" => "bedrock",
       "peekTime" => "3390",
       "processTime" => "1103",
       "totalTime" => "10461",
       "Content-Length" => "37",
     ],
     "rawBody" => "{"data":{},"jobID":2446,"name":"bar"}",
     "body" => [
       "data" => [],
       "jobID" => 2446,
       "name" => "bar",
     ],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-21 19:15:29",2446,"RUNNING","bar","2017-09-21 19:15:29","2017-09-21 19:15:35","",{},500,0,""]]}"
>>> $e = new RetryableException('retrying this jawn', 600)
=> Expensify\Bedrock\Exceptions\Jobs\RetryableException {#405
     #message: "retrying this jawn",
     #code: 666,
     #file: "/home/vagrant/.config/composer/vendor/psy/psysh/src/Psy/ExecutionLoop/Loop.php(90) : eval()'d code",
     #line: 1,
   }
>>> $jobs->retryJob($j['body']['jobID'], $e->getDelay(), $j['body']['data'], $e->getName(), $e->getNextRun())
=> [
     "codeLine" => "200 OK",
     "code" => 200,
     "headers" => [
       "commitCount" => "10376",
       "nodeName" => "bedrock",
       "peekTime" => "43",
       "processTime" => "1354",
       "totalTime" => "5470",
       "Content-Length" => "0",
     ],
     "rawBody" => "",
     "body" => [],
   ]
>>> $db->query("select * from jobs where jobID = ".$j['body']['jobID'])->toArray()['rawBody']
=> "{"headers":["created","jobID","state","name","nextRun","lastRun","repeat","data","priority","parentJobID","retryAfter"],"rows":[["2017-09-21 19:15:29",2446,"QUEUED","bar","2017-09-21 19:26:24","2017-09-21 19:15:35","",[],500,0,""]]}"
```