### PR TITLE
Fix IllegalAction exception message being wrongly specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ When you want to publish a new version:
 
 1. Create a new branch
 1. Commit your changes
-1. Update `/composer.json` to have the new version number
-1. Tag your branch with the new version number `git tag 1.0.4`
+1. Update `/composer.json` to have the new version number and commit those changes as well
+1. Tag your branch with the new version number, for example `git tag 1.0.4`
 1. Push you branch to the remote `git push origin HEAD --tags`
 1. Create a PR and assign it to someone for review

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.35",
+    "version": "1.0.36",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -110,7 +110,7 @@ class Jobs extends Plugin
         }
 
         if ($responseCode === 405) {
-            throw new IllegalAction("Cannot perform `$method` on job $job in a running state");
+            throw new IllegalAction("Cannot perform `$method` on job $job");
         }
 
         if ($responseCode === 502) {


### PR DESCRIPTION
@iwiznia, will you please review this?

The `405` response code is not specific to jobs in the `RUNNING` state anymore, therefore we shouldn't say so on the PHP layer.