### PR TITLE
Remove unused timeout parameter

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -148,7 +148,7 @@ try {
             // Ready to get a new job
             try {
                 // Query the server for a job
-                $response = $jobs->getJob($jobName, 60 * 1000); // Wait up to 60s
+                $response = $jobs->getJob($jobName);
             } catch (Exception $e) {
                 // Try again in 60 seconds
                 $logger->info('Problem getting job, retrying in 60s', ['message' => $e->getMessage()]);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.36",
+    "version": "1.0.37",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -192,19 +192,12 @@ class Jobs extends Plugin
      * Waits for a match (if requested) and atomically dequeues exactly one job.
      *
      * @param string $name
-     * @param int    $timeout (optional)
      *
      * @return array Containing all job details
      */
-    public function getJob($name, $timeout = 0)
+    public function getJob($name)
     {
         $headers = ["name" => $name];
-        if ($timeout) {
-            // Add the timeout
-            $headers["Connection"] = "wait";
-            $headers["timeout"]    = $timeout;
-            $headers["idempotent"] = true;
-        }
 
         return $this->call("GetJob", $headers);
     }
@@ -214,23 +207,15 @@ class Jobs extends Plugin
      *
      * @param string $name
      * @param int    $numResults
-     * @param int    $timeout (optional)
      *
      * @return array Containing all job details
      */
-    public function getJobs(string $name, int $numResults, int $timeout = 0) : array
+    public function getJobs(string $name, int $numResults) : array
     {
         $headers = [
             "name" => $name,
             "numResults" => $numResults,
         ];
-
-        if ($timeout) {
-            // Add the timeout
-            $headers["Connection"] = "wait";
-            $headers["timeout"]    = $timeout;
-            $headers["idempotent"] = true;
-        }
 
         return $this->call("GetJobs", $headers);
     }


### PR DESCRIPTION
@mea36 
cc @iwiznia 

Fixes: https://github.com/Expensify/Expensify/issues/63406

Removes unused timeout parameter. This is a problem as we now have a global `timeout` for all commands in bedrock. I'm aware there's an issue to bring back the previous version of `timeout`, but we'll need to do so with a different name.