### PR TITLE
Code to add retryAfter as the param for createJob

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.36",
+    "version": "1.0.37",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.37",
+    "version": "1.0.38",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -136,10 +136,11 @@ class Jobs extends Plugin
      * @param int         $priority    (optional) Specify a job priority. Jobs with higher priorities will be run first.
      * @param int|null    $parentJobID (optional) Specify this job's parent job.
      * @param string      $connection  (optional) Specify 'Connection' header using constants defined in this class.
+     * @param string|null $retryAfter  (optional) Specify when does this job need to be retried
      *
      * @return array Containing "jobID"
      */
-    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT)
+    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, $retryAfter = null)
     {
         $this->client->getLogger()->info("Create job", ['name' => $name]);
 
@@ -156,7 +157,8 @@ class Jobs extends Plugin
                 'Connection'  => $connection,
                 // If the name of the job has to be unique, Bedrock will return any existing job that exists with the
                 // given name instead of making a new one, which essentially makes the command idempotent.
-                'idempotent'  => $unique
+                'idempotent'  => $unique,
+                'retryAfter'  => $retryAfter
             ]
         );
 

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -132,11 +132,11 @@ class Jobs extends Plugin
      * @param array|null  $data        (optional)
      * @param string|null $firstRun    (optional)
      * @param string|null $repeat      (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
-     * @param bool        $unique      Do we want only one job with this name to exist?
-     * @param int         $priority    (optional) Specify a job priority. Jobs with higher priorities will be run first.
+     * @param bool|null   $unique      (optional) Do we want only one job with this name to exist?
+     * @param int|null    $priority    (optional) Specify a job priority. Jobs with higher priorities will be run first.
      * @param int|null    $parentJobID (optional) Specify this job's parent job.
-     * @param string      $connection  (optional) Specify 'Connection' header using constants defined in this class.
-     * @param string|null $retryAfter  (optional) Specify when does this job need to be retried
+     * @param string|null $connection  (optional) Specify 'Connection' header using constants defined in this class.
+     * @param string|null $retryAfter  (optional) Specify after what time in RUNNING this job should be retried (same syntax as repeat)
      *
      * @return array Containing "jobID"
      */
@@ -158,7 +158,7 @@ class Jobs extends Plugin
                 // If the name of the job has to be unique, Bedrock will return any existing job that exists with the
                 // given name instead of making a new one, which essentially makes the command idempotent.
                 'idempotent'  => $unique,
-                'retryAfter'  => $retryAfter
+                'retryAfter'  => $retryAfter,
             ]
         );
 


### PR DESCRIPTION
Part of the backend change needed to include `retryAfter` for the createJob.
Related to fixing issue - https://github.com/Expensify/Expensify/issues/53817

## Tests
1. Copy the changes over to `Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php`.
2. In psysh.sh run the following,
```
>>> use Expensify\Bedrock\Client;use Expensify\Bedrock\DB;use Expensify\Bedrock\Jobs;$c = new Client(); $jobs = new Jobs($c);$db = new DB($c)
=> Expensify\Bedrock\DB {#427}
>>> $jobs->createJob('testJob', null, null, null, false, 500, null, 'wait', '+1 hour');
[
     "headers" => [
       "commitCount" => "52552",
       "nodeName" => "bedrock",
       "peekTime" => "98",
       "processTime" => "3588",
       "totalTime" => "8033",
       "Content-Length" => "19",
     ],
     "body" => [
       "jobID" => 222198170,
     ],
     "size" => 138,
     "codeLine" => "200 OK",
     "code" => 200,
   ]
```
3. In bedrock.sql confirm the job was created with the retryAfter argument,
![image](https://user-images.githubusercontent.com/14356145/31253931-89811efe-a9db-11e7-83b8-0e85f0f420e4.png)
