### PR TITLE
Check for version file change in the safeToStartJob loop

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -399,10 +399,9 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
  *
  * Note: php's filemtime results are cached, so we need to clear
  *       that cache or we'll be getting a stale modified time.
- *
- * @return bool If version file changed
  */
- function checkVersionFile() {
+function checkVersionFile(string $versionWatchFile): bool
+{
      // Watch a version file that will cause us to automatically shut
      // down if it changes.  This enables triggering a restart if new
      // PHP is deployed.

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -402,19 +402,9 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
  */
 function checkVersionFile(string $versionWatchFile): bool
 {
-     // Watch a version file that will cause us to automatically shut
-     // down if it changes.  This enables triggering a restart if new
-     // PHP is deployed.
-     //
-     // Note: php's filemtime results are cached, so we need to clear
-     //       that cache or we'll be getting a stale modified time.
-     clearstatcache(true, $versionWatchFile);
-     $newVersionWatchFileTimestamp = ($versionWatchFile && file_exists($versionWatchFile)) ? filemtime($versionWatchFile) : false;
-     $versionChanged = $versionWatchFile && $newVersionWatchFileTimestamp !== $versionWatchFileTimestamp;
-
-    if ($versionChanged) {
-        $logger->info('Version watch file changed, stop processing new jobs');
-    }
+    clearstatcache(true, $versionWatchFile);
+    $newVersionWatchFileTimestamp = ($versionWatchFile && file_exists($versionWatchFile)) ? filemtime($versionWatchFile) : false;
+    $versionChanged = $versionWatchFile && $newVersionWatchFileTimestamp !== $versionWatchFileTimestamp;
 
     return $versionChanged;
 }

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Expensify\Bedrock\Client;
 use Expensify\Bedrock\Exceptions\Jobs\RetryableException;
 use Expensify\Bedrock\Jobs;
@@ -114,7 +116,7 @@ try {
                 throw new Exception('are you in a chroot?  If so, please make sure /proc is mounted correctly');
             }
 
-            if (checkVersionFile()) {
+            if (checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,
@@ -137,7 +139,7 @@ try {
         // Poll the server until we successfully get a job
         $response = null;
         while (!$response) {
-            if (checkVersionFile()) {
+            if (checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,
@@ -397,7 +399,7 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
  * Note: php's filemtime results are cached, so we need to clear
  *       that cache or we'll be getting a stale modified time.
  */
-function checkVersionFile(string $versionWatchFile): bool
+function checkVersionFile(string $versionWatchFile, int $versionWatchFileTimestamp): bool
 {
     clearstatcache(true, $versionWatchFile);
     $newVersionWatchFileTimestamp = ($versionWatchFile && file_exists($versionWatchFile)) ? filemtime($versionWatchFile) : false;

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -116,7 +116,7 @@ try {
                 throw new Exception('are you in a chroot?  If so, please make sure /proc is mounted correctly');
             }
 
-            if (checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
+            if ($versionWatchFile && checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,
@@ -139,7 +139,7 @@ try {
         // Poll the server until we successfully get a job
         $response = null;
         while (!$response) {
-            if (checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
+            if ($versionWatchFile && checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.42",
+    "version": "1.0.43",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
When BWM unfortunately gets stuck in the safeToStartJob (because of stuck jobs in the localJobsDB) the version watch file doesn't currently work, so I added a check in the loop to make sure it can still shut down properly when it's stuck in that loop.

Fixes https://github.com/Expensify/Expensify/issues/64494

# Tests
1. Run BWM with loadHandlerEnabled so it creates localJobsDB.sql
2. Fill the localJobsDB.sql with 10 dummy jobs with no closed date
3. Run BWM again with jobs queued, note that it keeps failing to start a job
4. `touch` the restart file, make sure it restarts correctly.