### PR TITLE
Add log line for when running jobs over target

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -308,7 +308,6 @@ try {
             $logger->warning("Failed to get job");
         }
     }
-
 } catch (Exception $e) {
     $message = $e->getMessage();
     $logger->alert('BedrockWorkerManager.php exited abnormally', ['exception' => $e]);

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -386,6 +386,8 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
         $logger->info("Jobs are slowing down, halving the target", ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
     }
 
+    $logger->info("Not queueing job, number of running jobs is above the target", ['numActive' => $numActive, 'target' => $target]);
+
     // Don't authorize BWM to call GetJobs
     return [false, $target];
 }

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -238,6 +238,7 @@ try {
                     $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrock, $jobs, $job, $extraParams, $logger, $localDB, $enableLoadHandler) {
                         $worker = new $workerName($bedrock, $job);
                         $childPID = getmypid();
+                        $localJobID = 0;
 
                         // Open the DB connection after the fork in the child process.
                         if ($enableLoadHandler) {
@@ -304,7 +305,7 @@ try {
         } elseif ($response['code'] == 303) {
             $logger->info("No job found, retrying.");
         } else {
-            $logger->warning("Failed to get job", ['codeLine' => $job['codeLine']]);
+            $logger->warning("Failed to get job");
         }
     }
 
@@ -333,11 +334,12 @@ $logger->info('Stopped BedrockWorkerManager');
  *
  * @return array First value is whether or not it is safe to start a new job, second is an updated $target value.
  */
-function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int $minSafeJobs, bool $enableLoadHandler, bool $debugThrottle, Psr\Log\LoggerInterface $logger) : array
+function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int $minSafeJobs, bool $enableLoadHandler, bool $debugThrottle, Psr\Log\LoggerInterface $logger): array
 {
     // Allow for disabling of the load handler.
     if (!$enableLoadHandler) {
         $logger->info("Load handler not enabled");
+
         return [true, $target];
     }
 
@@ -346,6 +348,7 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
     if ($numActive < $target) {
         // Still in a safe zone, don't worry about load
         $logger->info("Safe to start new job", ["numActive" => $numActive, "target" => $target]);
+
         return [true, $target];
     }
 
@@ -355,6 +358,7 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
         // Wait until we finish at least two batches of our target so we can evaluate its speed,
         // before expanding the batch.
         $logger->info("Haven't finished two batches of target, not queuing job", ["numActive" => $numActive, "target" => $target]);
+
         return [false, $target];
     }
 
@@ -380,7 +384,7 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
 
         // Authorize one more job given that we've just increased the target by one.
         return [true, $target];
-    } else if ($newBatchAverageTime > $maxSafeTime || $newBatchAverageTime < 1.5 * $oldBatchAverageTime) {
+    } elseif ($newBatchAverageTime > $maxSafeTime || $newBatchAverageTime < 1.5 * $oldBatchAverageTime) {
         // Things seem to be slowing down, pull our target back a lot
         $target = max(floor($target / 2), $minSafeJobs);
         $logger->info("Jobs are slowing down, halving the target", ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
@@ -393,7 +397,6 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
 }
 
 /**
- *
  * Watch a version file that will cause us to automatically shut
  * down if it changes.  This enables triggering a restart if new
  * PHP is deployed.

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -389,9 +389,8 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
         $logger->info("Jobs are slowing down, halving the target", ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
     }
 
-    $logger->info("Not queueing job, number of running jobs is above the target", ['numActive' => $numActive, 'target' => $target]);
-
     // Don't authorize BWM to call GetJobs
+    $logger->info("Not queueing job, number of running jobs is above the target", ['numActive' => $numActive, 'target' => $target]);
     return [false, $target];
 }
 

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -390,7 +390,8 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
     }
 
     // Don't authorize BWM to call GetJobs
-    $logger->info("Not queueing job, number of running jobs is above the target", ['numActive' => $numActive, 'target' => $target]);
+    $logger->info("Not queueing job, number of running jobs is above the target", ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
+
     return [false, $target];
 }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.43",
+    "version": "1.0.44",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
We want a better log line for when there are more running jobs than max jobs so we can accurately track when we're being throttled by AIMD.

# Test
1. Create 30 jobs
2. Set ended to null in the last 10
3. Run BWM with `--enableLoadHandler`
4. Look for this line in the logs:
```
Nov  2 21:14:52 vagrant-ubuntu-trusty-64 php: s7W5Q4 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Not queueing job, number of running jobs is above the target ~~ numActive: '10' target: '10'
```