### PR TITLE
Add connection retries as configuration option to bedrock client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.50",
+    "version": "1.0.51",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.44",
+    "version": "1.0.49",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
@iwiznia , will you please review this?

This PR adds the number of retries the bedrock client is allotted to connect to the server as a configuration options.

Fixes https://github.com/Expensify/Expensify/issues/64873 and https://github.com/Expensify/Expensify/issues/65058

Note, the remaining phan errors are a bug with phan. I believe they can be ignored.
Also note, that the there is an accompanying [web pr](https://github.com/Expensify/Web-Expensify/pull/19151).

# Tests
None

# QA
None