### PR TITLE
Ensure safeToStartANewJob returns an int as the target

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -362,7 +362,6 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
     }
 
     // Calculate the speed of the last 2 batches to see if we're speeding up or slowing down
-    $oldBatchAverageTime = 0;
     $oldBatchTimes = $localDB->read("SELECT CAST(STRFTIME('%s', ended) - STRFTIME('%s', started) AS int) FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT $target OFFSET $target;");
     $oldBatchAverageTime = array_sum($oldBatchTimes) / count($oldBatchTimes);
     $newBatchAverageTime = $localDB->read("SELECT SUM(CAST(STRFTIME('%s', ended) - strftime('%s', started) AS int)) / count(*) FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT $target;")[0];
@@ -385,7 +384,7 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
         return [true, $target];
     } elseif ($newBatchAverageTime > $maxSafeTime || $newBatchAverageTime < 1.5 * $oldBatchAverageTime) {
         // Things seem to be slowing down, pull our target back a lot
-        $target = max(floor($target / 2), $minSafeJobs);
+        $target = intval(max(floor($target / 2), $minSafeJobs));
         $logger->info("Jobs are slowing down, halving the target", ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.44",
+    "version": "1.0.46",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
@mattabullock 
cc @iwiznia 
See https://github.com/Expensify/Expensify/issues/65705 -- logs are throwing `Argument 2 passed to safeToStartANewJob() must be of the type integer, float given, called in /git/expensify.com/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php on line 129'`. This is the only place I could find that doesn't return an int (funnily enough, `floor` does not return an `int`) 

Not tested. LMK if this is right, and we can build the package. 