### PR TITLE
Allow db results to be returned as associative arrays with column names as keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.49",
+    "version": "1.0.50",
     "authors": [
         {
             "name": "Expensify",

--- a/src/DB/Response.php
+++ b/src/DB/Response.php
@@ -2,8 +2,8 @@
 
 namespace Expensify\Bedrock\DB;
 
-use JsonSerializable;
 use Countable;
+use JsonSerializable;
 
 /**
  * Base class for Bedrock plugins.
@@ -131,6 +131,7 @@ class Response implements JsonSerializable, Countable
      * Get the rows returned.
      *
      * @param bool $assoc Do we want to return each row keyed by the column name? If not, they will be keyed by index.
+     *
      * @return array[]
      */
     public function getRows(bool $assoc = false): array

--- a/src/DB/Response.php
+++ b/src/DB/Response.php
@@ -130,11 +130,25 @@ class Response implements JsonSerializable, Countable
     /**
      * Get the rows returned.
      *
+     * @param bool $assoc Do we want to return each row keyed by the column name? If not, they will be keyed by index.
      * @return array[]
      */
-    public function getRows()
+    public function getRows(bool $assoc = false): array
     {
-        return $this->getFromContainer(['body', 'rows'], []);
+        $rows = $this->getFromContainer(['body', 'rows'], []);
+        if (!$assoc) {
+            return $rows;
+        }
+        $results = [];
+        $headers = $this->getHeaders();
+        foreach ($rows as $row) {
+            $result = [];
+            foreach ($headers as $index => $header) {
+                $result[$header] = $row[$index];
+            }
+            $results[] = $result;
+        }
+        return $results;
     }
 
     /**


### PR DESCRIPTION
Needed for https://github.com/Expensify/Web-Expensify/pull/19213

Tests:
- Call getRows with no param, check results are returned the same as before.
- Call getRows with true as a param, check the results are returned keyed by column. 