### PR TITLE
Use GetJobs instead of GetJob

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -49,6 +49,7 @@ $maxLoad = floatval($options['maxLoad'] ?? 1.0); // Max load of 1.0 by default
 $maxIterations = intval($options['maxIterations'] ?? -1); // Unlimited iterations by default
 $pathToDB = $options['localJobsDBPath'] ?? '/tmp/localJobsDB.sql';
 $minSafeJobs = intval($options['minSafeJobs'] ?? 10);  // The minimum number of jobs before we start paying attention
+$maxJobsForSingleRun = intval($options['maxJobsInSingleRun'] ?? 10);
 $maxSafeTime = intval($options['maxSafeTime'] ?? 0); // The maximum job time before we start paying attention
 $debugThrottle = isset($options['debugThrottle']); // Set to true to maintain a debug history
 $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD load handler
@@ -126,12 +127,12 @@ try {
 
             // Check if we can fork based on the load of our webservers
             $load = sys_getloadavg()[0];
-            list($safeToStartANewJob, $target) = safeToStartANewJob($localDB, $target, $maxSafeTime, $minSafeJobs, $enableLoadHandler, $debugThrottle, $logger);
-            if ($load < $maxLoad && $safeToStartANewJob) {
-                $logger->info('Safe to start a new job, checking for more work', ['load' => $load, 'MAX_LOAD' => $maxLoad]);
+            list($jobsToQueue, $target) = getNumberOfJobsToQueue($localDB, $target, $maxSafeTime, $minSafeJobs, $enableLoadHandler, $maxJobsForSingleRun, $debugThrottle, $logger);
+            if ($load < $maxLoad && $jobsToQueue > 0) {
+                $logger->info('Safe to start a new job, checking for more work', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 break;
             } else {
-                $logger->info('Not safe to start a new job, waiting 1s and trying again.', ['load' => $load, 'MAX_LOAD' => $maxLoad]);
+                $logger->info('Not safe to start a new job, waiting 1s and trying again.', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 sleep(1);
             }
         }
@@ -150,7 +151,7 @@ try {
             // Ready to get a new job
             try {
                 // Query the server for a job
-                $response = $jobs->getJob($jobName);
+                $response = $jobs->getJobs($jobName, $jobsToQueue);
             } catch (Exception $e) {
                 // Try again in 60 seconds
                 $logger->info('Problem getting job, retrying in 60s', ['message' => $e->getMessage()]);
@@ -180,127 +181,124 @@ try {
             // selectively.  For example, you may have separate jobs scheduled
             // as production/jobName and staging/jobName, with a WorkerManager
             // in each environment looking for each path.
-            $job = $response['body'];
-            $parts = explode('/', $job['name']);
-            $jobParts = explode('?', $job['name']);
-            $extraParams = count($jobParts) > 1 ? $jobParts[1] : null;
-            $job['name'] = $jobParts[0];
-            $workerName = $parts[count($parts) - 1];
-            $workerName = explode('?', $workerName)[0];
-            $workerFilename = $workerPath."/$workerName.php";
-            $logger->info("Looking for worker '$workerFilename'");
-            if (file_exists($workerFilename)) {
-                // The file seems to exist -- fork it so we can run it.
-                //
-                // Note: By explicitly ignoring SIGCHLD we tell the kernel to
-                //       "reap" finished child processes automatically, rather
-                //       than creating "zombie" processes.  (We don't care
-                //       about the child's exit code, so we have no use for the
-                //       zombie process.)
-                $logger->info("Forking and running a worker.", [
-                    'workerFileName' => $workerFilename,
-                ]);
-
-                // Close DB connection before forking.
-                if ($enableLoadHandler) {
-                    $localDB->close();
-                }
-                pcntl_signal(SIGCHLD, SIG_IGN);
-                $pid = pcntl_fork();
-                if ($pid == -1) {
-                    // Something went wrong, couldn't fork
-                    $errorMessage = pcntl_strerror(pcntl_get_last_error());
-                    throw new Exception("Unable to fork because '$errorMessage', aborting.");
-                } elseif ($pid == 0) {
-                    // If we are using a global REQUEST_ID, reset it to indicate this is a new process.
-                    $logger->info("Fork succeeded, child process, running job", [
-                        'name' => $job['name'],
-                        'id' => $job['jobID'],
-                        'extraParams' => $extraParams,
+            $jobsToRun = $response['body']['jobs'];
+            foreach ($jobsToRun as $job) {
+                $parts = explode('/', $job['name']);
+                $jobParts = explode('?', $job['name']);
+                $extraParams = count($jobParts) > 1 ? $jobParts[1] : null;
+                $job['name'] = $jobParts[0];
+                $workerName = $parts[count($parts) - 1];
+                $workerName = explode('?', $workerName)[0];
+                $workerFilename = $workerPath."/$workerName.php";
+                $logger->info("Looking for worker '$workerFilename'");
+                if (file_exists($workerFilename)) {
+                    // The file seems to exist -- fork it so we can run it.
+                    //
+                    // Note: By explicitly ignoring SIGCHLD we tell the kernel to
+                    //       "reap" finished child processes automatically, rather
+                    //       than creating "zombie" processes.  (We don't care
+                    //       about the child's exit code, so we have no use for the
+                    //       zombie process.)
+                    $logger->info("Forking and running a worker.", [
+                        'workerFileName' => $workerFilename,
                     ]);
-                    if (isset($GLOBALS['REQUEST_ID'])) {
-                        // Reset the REQUEST_ID and re-log the line so we see
-                        // it when searching for either the parent and child
-                        // REQUEST_IDs.
-                        $GLOBALS['REQUEST_ID'] = substr(str_replace(['+', '/'], 'x', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
+
+                    // Close DB connection before forking.
+                    if ($enableLoadHandler) {
+                        $localDB->close();
+                    }
+                    pcntl_signal(SIGCHLD, SIG_IGN);
+                    $pid = pcntl_fork();
+                    if ($pid == -1) {
+                        // Something went wrong, couldn't fork
+                        $errorMessage = pcntl_strerror(pcntl_get_last_error());
+                        throw new Exception("Unable to fork because '$errorMessage', aborting.");
+                    } elseif ($pid == 0) {
+                        // If we are using a global REQUEST_ID, reset it to indicate this is a new process.
+                        if (isset($GLOBALS['REQUEST_ID'])) {
+                            // Reset the REQUEST_ID and re-log the line so we see
+                            // it when searching for either the parent and child
+                            // REQUEST_IDs.
+                            $GLOBALS['REQUEST_ID'] = substr(str_replace(['+', '/'], 'x', base64_encode(openssl_random_pseudo_bytes(6))), 0, 6); // random 6 character ID
+                        }
                         $logger->info("Fork succeeded, child process, running job", [
                             'name' => $job['name'],
                             'id' => $job['jobID'],
                             'extraParams' => $extraParams,
                         ]);
-                    }
-                    $stats->counter('bedrockJob.create.'.$job['name']);
+                        $stats->counter('bedrockJob.create.'.$job['name']);
 
-                    // Include the worker now (not in the parent thread) such
-                    // that we automatically pick up new versions over the
-                    // worker without needing to restart the parent.
-                    include_once $workerFilename;
-                    $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrock, $jobs, $job, $extraParams, $logger, $localDB, $enableLoadHandler) {
-                        $worker = new $workerName($bedrock, $job);
-                        $childPID = getmypid();
-                        $localJobID = 0;
+                        // Include the worker now (not in the parent thread) such
+                        // that we automatically pick up new versions over the
+                        // worker without needing to restart the parent.
+                        include_once $workerFilename;
+                        $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrock, $jobs, $job, $extraParams, $logger, $localDB, $enableLoadHandler) {
+                            $worker = new $workerName($bedrock, $job);
+                            $childPID = getmypid();
+                            $localJobID = 0;
 
-                        // Open the DB connection after the fork in the child process.
+                            // Open the DB connection after the fork in the child process.
+                            if ($enableLoadHandler) {
+                                $localDB->open();
+                                $localDB->write("INSERT INTO localJobs (pid, jobID, jobName, started) VALUES ($childPID, {$job['jobID']}, '{$job['name']}', DATETIME('now'));");
+                                $localJobID = $localDB->getLastInsertedRowID();
+                            }
+                            try {
+                                // Run the worker.  If it completes successfully, finish the job.
+                                $worker->run();
+
+                                // Success
+                                $logger->info("Job completed successfully, exiting.", [
+                                    'name' => $job['name'],
+                                    'id' => $job['jobID'],
+                                    'extraParams' => $extraParams,
+                                ]);
+                                $jobs->finishJob($job['jobID'], $worker->getData());
+                            } catch (RetryableException $e) {
+                                // Worker had a recoverable failure; retry again later.
+                                $logger->info("Job could not complete, retrying.", [
+                                    'name' => $job['name'],
+                                    'id' => $job['jobID'],
+                                    'extraParams' => $extraParams,
+                                ]);
+                                $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
+                            } catch (Throwable $e) {
+                                $logger->alert("Job failed with errors, exiting.", [
+                                    'name' => $job['name'],
+                                    'id' => $job['jobID'],
+                                    'extraParams' => $extraParams,
+                                    'exception' => $e,
+                                ]);
+                                // Worker had a fatal error -- mark as failed.
+                                $jobs->failJob($job['jobID']);
+                            } finally {
+                                if ($enableLoadHandler) {
+                                    $localDB->write("UPDATE localJobs SET ended=DATETIME('now') WHERE localJobID=$localJobID;");
+                                }
+                            }
+                        });
+
+                        // The forked worker process is all done.
+                        $stats->counter('bedrockJob.finish.'.$job['name']);
+                        exit(1);
+                    } else {
+                        // Reopen the DB connection in the parent thread.
                         if ($enableLoadHandler) {
                             $localDB->open();
-                            $localDB->write("INSERT INTO localJobs (pid, jobID, jobName, started) VALUES ($childPID, {$job['jobID']}, '{$job['name']}', DATETIME('now'));");
-                            $localJobID = $localDB->getLastInsertedRowID();
                         }
-                        try {
-                            // Run the worker.  If it completes successfully, finish the job.
-                            $worker->run();
 
-                            // Success
-                            $logger->info("Job completed successfully, exiting.", [
-                                'name' => $job['name'],
-                                'id' => $job['jobID'],
-                                'extraParams' => $extraParams,
-                            ]);
-                            $jobs->finishJob($job['jobID'], $worker->getData());
-                        } catch (RetryableException $e) {
-                            // Worker had a recoverable failure; retry again later.
-                            $logger->info("Job could not complete, retrying.", [
-                                'name' => $job['name'],
-                                'id' => $job['jobID'],
-                                'extraParams' => $extraParams,
-                            ]);
-                            $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
-                        } catch (Throwable $e) {
-                            $logger->alert("Job failed with errors, exiting.", [
-                                'name' => $job['name'],
-                                'id' => $job['jobID'],
-                                'extraParams' => $extraParams,
-                                'exception' => $e,
-                            ]);
-                            // Worker had a fatal error -- mark as failed.
-                            $jobs->failJob($job['jobID']);
-                        } finally {
-                            if ($enableLoadHandler) {
-                                $localDB->write("UPDATE localJobs SET ended=DATETIME('now') WHERE localJobID=$localJobID;");
-                            }
-                        }
-                    });
-
-                    // The forked worker process is all done.
-                    $stats->counter('bedrockJob.finish.'.$job['name']);
-                    exit(1);
-                } else {
-                    // Reopen the DB connection in the parent thread.
-                    if ($enableLoadHandler) {
-                        $localDB->open();
+                        // Otherwise we are the parent thread -- continue execution
+                        $logger->info("Successfully ran job", [
+                            'name' => $job['name'],
+                            'id' => $job['jobID'],
+                            'pid' => $pid,
+                        ]);
                     }
-
-                    // Otherwise we are the parent thread -- continue execution
-                    $logger->info("Successfully ran job", [
-                        'name' => $job['name'],
-                        'id' => $job['jobID'],
-                        'pid' => $pid,
-                    ]);
+                } else {
+                    // No worker for this job
+                    $logger->warning('No worker found, ignoring', ['jobName' => $job['name']]);
+                    $jobs->failJob($job['jobID']);
                 }
-            } else {
-                // No worker for this job
-                $logger->warning('No worker found, ignoring', ['jobName' => $job['name']]);
-                $jobs->failJob($job['jobID']);
             }
         } elseif ($response['code'] == 303) {
             $logger->info("No job found, retrying.");
@@ -331,24 +329,24 @@ $logger->info('Stopped BedrockWorkerManager');
  * @param bool                    $debugThrottle     If true, doesn't delete jobs from localDB
  * @param Psr\Log\LoggerInterface $logger
  *
- * @return array First value is whether or not it is safe to start a new job, second is an updated $target value.
+ * @return array First value how many jobs it is safe to queue, second is an updated $target value.
  */
-function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int $minSafeJobs, bool $enableLoadHandler, bool $debugThrottle, Psr\Log\LoggerInterface $logger): array
+function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime, int $minSafeJobs, bool $enableLoadHandler, int $maxJobsForSingleRun, bool $debugThrottle, Psr\Log\LoggerInterface $logger): array
 {
     // Allow for disabling of the load handler.
     if (!$enableLoadHandler) {
         $logger->info("Load handler not enabled");
 
-        return [true, $target];
+        return [$maxJobsForSingleRun, $target];
     }
 
     // Have we hit our target job count?
     $numActive = $localDB->read('SELECT COUNT(*) FROM localJobs WHERE ended IS NULL;')[0];
     if ($numActive < $target) {
         // Still in a safe zone, don't worry about load
-        $logger->info("Safe to start new job", ["numActive" => $numActive, "target" => $target]);
+        $logger->info("Safe to start new job", ["numberOfJobsToQueue" => $target - $numActive, "numActive" => $numActive, "target" => $target]);
 
-        return [true, $target];
+        return [$target - $numActive, $target];
     }
 
     // We're at or over our target; do we have enough data to evaluate the speed?
@@ -356,9 +354,9 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
     if ($numFinished < $target * 2) {
         // Wait until we finish at least two batches of our target so we can evaluate its speed,
         // before expanding the batch.
-        $logger->info("Haven't finished two batches of target, not queuing job", ["numActive" => $numActive, "target" => $target]);
+        $logger->info("Haven't finished two batches of target, not queuing job", ['numberOfJobsToQueue' => 0, 'numActive' => $numActive, 'target' => $target]);
 
-        return [false, $target];
+        return [0, $target];
     }
 
     // Calculate the speed of the last 2 batches to see if we're speeding up or slowing down
@@ -370,8 +368,8 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
         // it's going roughly the same speed as the batch before.  This suggests that we
         // haven't hit any serious bottleneck yet, so let's dial it up ever so slightly and see
         // if speeds hold at the new target.
-        $logger->info('Increasing target', ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
         $target++;
+        $logger->info('Increasing target', ['numberOfJobsToQueue' => $target - $numActive, 'newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
 
         // Also, blow away any data from more than two batches ago, because we don't
         // look farther back than that and don't want to accumulate data infinitely.  However,
@@ -381,17 +379,17 @@ function safeToStartANewJob(LocalDB $localDB, int $target, int $maxSafeTime, int
         }
 
         // Authorize one more job given that we've just increased the target by one.
-        return [true, $target];
+        return [$target - $numActive, $target];
     } elseif ($newBatchAverageTime > $maxSafeTime || $newBatchAverageTime < 1.5 * $oldBatchAverageTime) {
         // Things seem to be slowing down, pull our target back a lot
         $target = intval(max(floor($target / 2), $minSafeJobs));
-        $logger->info("Jobs are slowing down, halving the target", ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
+        $logger->info("Jobs are slowing down, halving the target", ['numberOfJobsToQueue' => $target - $numActive, 'newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
     }
 
     // Don't authorize BWM to call GetJobs
-    $logger->info("Not queueing job, number of running jobs is above the target", ['newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
+    $logger->info("Not queueing job, number of running jobs is above the target", ['numberOfJobsToQueue' => $target - $numActive, 'newBatchAverageTime' => $newBatchAverageTime, 'oldBatchAverageTime' => $oldBatchAverageTime, 'numActive' => $numActive, 'target' => $target]);
 
-    return [false, $target];
+    return [0, $target];
 }
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.51",
+    "version": "1.0.52",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Doing individual `GetJob` calls is causing too much synchronous time on the network, so we're attempting to optimize out the network time by returning multiple jobs every time with `GetJobs`.

# Tests
1. Queue tons of jobs
2. Run BWM
3. Look for this log line

```
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '1' numActive: '13' target: '14'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '1' numActive: '14' target: '15'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '1' numActive: '15' target: '16'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '1' numActive: '17' target: '18'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '1' numActive: '17' target: '18'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '10' numActive: '9' target: '19'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '10' numActive: '9' target: '19'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '13' numActive: '6' target: '19'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '5' numActive: '14' target: '19'
vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Safe to start new job ~~ numberOfJobsToQueue: '3' numActive: '16' target: '19'
```