### PR TITLE
Reuse sockets

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -56,7 +56,7 @@ $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD l
 $target = $minSafeJobs;
 
 // Configure the Bedrock client with these command-line options
-$bedrock = Client::get($options);
+$bedrock = Client::getInstance($options);
 
 // Prepare to use the host logger, if configured
 $logger = $bedrock->getLogger();

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -280,6 +280,11 @@ try {
 
                         // The forked worker process is all done.
                         $stats->counter('bedrockJob.finish.'.$job['name']);
+
+                        // This is a long running process, child and parent share the socket cache because it's stored
+                        // in a static variable, so here we make sure that we close the sockets used by the child
+                        // process so we don't keep them open till the parent process finishes.
+                        Client::closeSocketsForPID();
                         exit(1);
                     } else {
                         // Reopen the DB connection in the parent thread.

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -214,6 +214,10 @@ try {
                         $errorMessage = pcntl_strerror(pcntl_get_last_error());
                         throw new Exception("Unable to fork because '$errorMessage', aborting.");
                     } elseif ($pid == 0) {
+                        // We forked, so we need to make sure the bedrock client opens new sockets inside this for,
+                        // instead of reusing the ones created by the parent process.
+                        Client::clearSocketsAfterFork();
+
                         // If we are using a global REQUEST_ID, reset it to indicate this is a new process.
                         if (isset($GLOBALS['REQUEST_ID'])) {
                             // Reset the REQUEST_ID and re-log the line so we see
@@ -280,11 +284,6 @@ try {
 
                         // The forked worker process is all done.
                         $stats->counter('bedrockJob.finish.'.$job['name']);
-
-                        // This is a long running process, child and parent share the socket cache because it's stored
-                        // in a static variable, so here we make sure that we close the sockets used by the child
-                        // process so we don't keep them open till the parent process finishes.
-                        Client::closeSocketsForPID();
                         exit(1);
                     } else {
                         // Reopen the DB connection in the parent thread.

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -56,7 +56,7 @@ $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD l
 $target = $minSafeJobs;
 
 // Configure the Bedrock client with these command-line options
-$bedrock = new Client($options);
+$bedrock = Client::get($options);
 
 // Prepare to use the host logger, if configured
 $logger = $bedrock->getLogger();
@@ -216,7 +216,7 @@ try {
                     } elseif ($pid == 0) {
                         // We forked, so we need to make sure the bedrock client opens new sockets inside this for,
                         // instead of reusing the ones created by the parent process.
-                        Client::clearSocketsAfterFork();
+                        Client::clearInstancesAfterFork();
 
                         // If we are using a global REQUEST_ID, reset it to indicate this is a new process.
                         if (isset($GLOBALS['REQUEST_ID'])) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.52",
+    "version": "1.1.0",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -289,7 +289,7 @@ class Client implements LoggerAwareInterface
             reset($hostConfigs);
             $numRetriesLeft = count($hostConfigs) - 1;
 
-            // If we already have a socket for this pid and cluster, then we first try to reuse it
+            // If we already have a socket for this instance, then we first try to reuse it
             if ($this->socket) {
                 $hostName = $this->lastHost;
             } else {

--- a/src/Client.php
+++ b/src/Client.php
@@ -144,7 +144,7 @@ class Client implements LoggerAwareInterface
      * Returns an instance of this class for the specified configuration. It will return the same instance if the same
      * configuration was passed, unless clearInstancesAfterFork is called.
      */
-    public static function get(array $config = []): Client
+    public static function getInstance(array $config = []): Client
     {
         $config = array_merge(self::$defaultConfig, $config);
         ksort($config);
@@ -152,7 +152,7 @@ class Client implements LoggerAwareInterface
         if (isset(self::$instances[$hash])) {
             return self::$instances[$hash];
         }
-        $instance = new Client($config);
+        $instance = new self($config);
         self::$instances[$hash] = $instance;
 
         return $instance;

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -174,7 +174,7 @@ class Jobs extends Plugin
      *
      * @return array - contain the jobIDs with the unique identifier of the created jobs
      */
-    public function createJobs(array $jobs) : array
+    public function createJobs(array $jobs): array
     {
         $this->client->getLogger()->info("Create jobs", ['jobs' => $jobs]);
 
@@ -212,7 +212,7 @@ class Jobs extends Plugin
      *
      * @return array Containing all job details
      */
-    public function getJobs(string $name, int $numResults) : array
+    public function getJobs(string $name, int $numResults): array
     {
         $headers = [
             "name" => $name,
@@ -225,9 +225,9 @@ class Jobs extends Plugin
     /**
      * Updates the data associated with a job.
      *
-     * @param int   $jobID
-     * @param array $data
-     * @param string $repeat      (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param int    $jobID
+     * @param array  $data
+     * @param string $repeat (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
      *
      * @return array
      */
@@ -271,12 +271,12 @@ class Jobs extends Plugin
      *
      * @return array
      */
-    public function cancelJob(int $jobID) : array
+    public function cancelJob(int $jobID): array
     {
         return $this->call(
             "CancelJob",
             [
-                "jobID" => $jobID
+                "jobID" => $jobID,
             ]
         );
     }
@@ -382,8 +382,8 @@ class Jobs extends Plugin
      */
     public static function queueJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT)
     {
+        $bedrock = Client::getInstance();
         try {
-            $bedrock = Client::get();
             $jobs = new self($bedrock);
 
             return $jobs->createJob($name, $data, $firstRun, $repeat, $unique, $priority, $parentJobID, $connection);

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -383,7 +383,7 @@ class Jobs extends Plugin
     public static function queueJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT)
     {
         try {
-            $bedrock = new Client();
+            $bedrock = Client::get();
             $jobs = new self($bedrock);
 
             return $jobs->createJob($name, $data, $firstRun, $repeat, $unique, $priority, $parentJobID, $connection);


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/66144

This introduces socket reutilization to the bedrock Client class. In order to support being used in a multi threaded environment, like in BWM, it stores the sockets per pid, cluster and host name.

/cc @quinthar 