### PR TITLE
Change BWM queries to work more effectively

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -240,7 +240,7 @@ try {
                             // Open the DB connection after the fork in the child process.
                             if ($enableLoadHandler) {
                                 $localDB->open();
-                                $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$job['name']}', ".microtime(true).");");
+                                $localDB->write("INSERT INTO localJobs (pid, jobID, jobName, started) VALUES ($childPID, {$job['jobID']}, '{$job['name']}', ".microtime(true).");");
                                 $localJobID = $localDB->getLastInsertedRowID();
                             }
                             try {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.0.52",
+    "version": "1.0.53",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Two things here:

1. Change it to use microtime instead of SQL DATETIME - datetime has terrible accuracy, only down to the second. Most of our jobs take less than a second, so that's not super helpful.
2. Calculate the average time outside of SQL - Turns out when you limit by target but do a SUM in sqlite, it still sums everything, disregarding the limit completely. 

# Tests
1. Queue tons of jobs
2. Check DB
3. Verify jobs are now shown as floats in the db
```
sqlite> SELECT started, ended FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT 10;
1511223595.47|1511223596.49
1511223595.29|1511223596.31
1511223595.44|1511223595.47
...
```
4. Verify jobs still queue correctly.