### PR TITLE
Fix new maxJobsInSingleRun param

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -32,14 +32,14 @@ if (php_sapi_name() !== "cli") {
 }
 
 // Parse the command line and verify the required settings are provided
-$options = getopt('', ['maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 'stats::', 'workerPath::', 'versionWatchFile::', 'writeConsistency::', 'enableLoadHandler', 'minSafeJobs::', 'maxSafeTime::', 'localJobsDBPath::', 'debugThrottle']);
+$options = getopt('', ['maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 'stats::', 'workerPath::', 'versionWatchFile::', 'writeConsistency::', 'enableLoadHandler', 'minSafeJobs::', 'maxJobsInSingleRun::', 'maxSafeTime::', 'localJobsDBPath::', 'debugThrottle']);
 
 // Store parent ID to determine if we should continue forking
 $thisPID = getmypid();
 
 $workerPath = @$options['workerPath'];
 if (!$workerPath) {
-    echo "Usage: sudo -u user php ./bin/BedrockWorkerManager.php --workerPath=<workerPath> [--jobName=<jobName> --maxLoad=<maxLoad> --maxIterations=<iteration> --writeConsistency=<consistency>  --enableLoadHandler --minSafeJobs=<minSafeJobs> --maxSafeTime=<maxSafeTime> --localJobsDBPath=<localJobsDBPath> --debugThrottle]\r\n";
+    echo "Usage: sudo -u user php ./bin/BedrockWorkerManager.php --workerPath=<workerPath> [--jobName=<jobName> --maxLoad=<maxLoad> --maxIterations=<iteration> --writeConsistency=<consistency>  --enableLoadHandler --minSafeJobs=<minSafeJobs> --maxJobsInSingleRun=<maxJobsInSingleRun> --maxSafeTime=<maxSafeTime> --localJobsDBPath=<localJobsDBPath> --debugThrottle]\r\n";
     exit(1);
 }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Please don't merge without letting me create a new release first. Maybe we could make it part of the approval process to have the approver package it? I dunno, just a thought. Makes it so we'd have fewer of the awful conflicts that people have with the versions.

---

Huge oversight in the recent GetJobs PR... forgot to make BWM read the parameter at all, so it just defaulted to 10. This is fine right now because we're just testing with the default, but obviously we'd like to be able to change it.

# Tests
1. Queue 15 jobs
2. Run BWM with `--maxJobsInSingleRun=15 --minSafeJobs=15`
3. Confirm that the first run through AIMD shows this log line:
```
[info] Safe to start new job ~~ numberOfJobsToQueue: '15' numActive: '0' target: '15'
```