### PR TITLE
Fix getInstance to not use the logger and stats params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -158,13 +158,16 @@ class Client implements LoggerAwareInterface
 
     /**
      * Returns an instance of this class for the specified configuration. It will return the same instance if the same
-     * configuration was passed, unless clearInstancesAfterFork is called.
+     * configuration was passed (not counting the logger and stats params), unless clearInstancesAfterFork is called.
      */
     public static function getInstance(array $config = []): Client
     {
         $config = array_merge(self::$defaultConfig, $config);
         ksort($config);
-        $hash = sha1(print_r($config, true));
+        $configForHash = $config;
+        unset($configForHash['logger']);
+        unset($configForHash['stats']);
+        $hash = sha1(print_r($configForHash, true));
         if (isset(self::$instances[$hash])) {
             return self::$instances[$hash];
         }


### PR DESCRIPTION
@flodnv please review. DO NOT merge, I need to create the tag.

Context https://expensify.slack.com/archives/C0BS1NT42/p1512049104000222

Tests:
Before:
```
>>>  $logger = new Expensify\Logger();                                                                                                                                                                                                                                        => Expensify\Logger {#379}
>>>         $client = Expensify\Bedrock\Client::getInstance([                                                                                                                                                                                                                             'clusterName' => 'auth',                                                                                                                                                                                                                                                      'mainHostConfigs' => AUTH_HOSTS,                                                                                                                                                                                                                                              'failoverHostConfigs' => AUTH_FAILOVERS,                                                                                                                                                                                                                                      'connectionTimeout' => 1,                                                                                                                                                                                                                                                     'readTimeout' => 300,                                                                                                                                                                                                                                                         'maxBlackListTimeout' => 60,                                                                                                                                                                                                                                                  'logger' => $logger,                                                                                                                                                                                                                                                      ])
=> Expensify\Bedrock\Client {#410}
>>>         $client = Expensify\Bedrock\Client::getInstance([                                                                                                                                                                                                                             'clusterName' => 'auth',                                                                                                                                                                                                                                                      'mainHostConfigs' => AUTH_HOSTS,                                                                                                                                                                                                                                              'failoverHostConfigs' => AUTH_FAILOVERS,                                                                                                                                                                                                                                      'connectionTimeout' => 1,                                                                                                                                                                                                                                                     'readTimeout' => 300,                                                                                                                                                                                                                                                         'maxBlackListTimeout' => 60,                                                                                                                                                                                                                                                  'logger' => $logger,                                                                                                                                                                                                                                                      ])
=> Expensify\Bedrock\Client {#410}
>>> $logger->setSensitiveKeys(['caca'])                                                                                                                                                                                                                                       => null
>>>         $client = Expensify\Bedrock\Client::getInstance([                                                                                                                                                                                                                             'clusterName' => 'auth',                                                                                                                                                                                                                                                      'mainHostConfigs' => AUTH_HOSTS,                                                                                                                                                                                                                                              'failoverHostConfigs' => AUTH_FAILOVERS,                                                                                                                                                                                                                                      'connectionTimeout' => 1,                                                                                                                                                                                                                                                     'readTimeout' => 300,                                                                                                                                                                                                                                                         'maxBlackListTimeout' => 60,                                                                                                                                                                                                                                                  'logger' => $logger,                                                                                                                                                                                                                                                      ])
=> Expensify\Bedrock\Client {#413}
```
After:
```
>>>  $logger = new Expensify\Logger();
=> Expensify\Logger {#379}
>>>         $client = Expensify\Bedrock\Client::getInstance([                                                                                                                                                                                                                             'clusterName' => 'auth',                                                                                                                                                                                                                                                      'mainHostConfigs' => AUTH_HOSTS,                                                                                                                                                                                                                                              'failoverHostConfigs' => AUTH_FAILOVERS,                                                                                                                                                                                                                                      'connectionTimeout' => 1,                                                                                                                                                                                                                                                     'readTimeout' => 300,                                                                                                                                                                                                                                                         'maxBlackListTimeout' => 60,                                                                                                                                                                                                                                                  'logger' => $logger,                                                                                                                                                                                                                                                      ])
=> Expensify\Bedrock\Client {#441}
>>>         $client = Expensify\Bedrock\Client::getInstance([                                                                                                                                                                                                                             'clusterName' => 'auth',                                                                                                                                                                                                                                                      'mainHostConfigs' => AUTH_HOSTS,                                                                                                                                                                                                                                              'failoverHostConfigs' => AUTH_FAILOVERS,                                                                                                                                                                                                                                      'connectionTimeout' => 1,                                                                                                                                                                                                                                                     'readTimeout' => 300,                                                                                                                                                                                                                                                         'maxBlackListTimeout' => 60,                                                                                                                                                                                                                                                  'logger' => $logger,                                                                                                                                                                                                                                                      ])
=> Expensify\Bedrock\Client {#441}
>>> $logger->setSensitiveKeys(['caca'])
=> null
>>>         $client = Expensify\Bedrock\Client::getInstance([                                                                                                                                                                                                                             'clusterName' => 'auth',                                                                                                                                                                                                                                                      'mainHostConfigs' => AUTH_HOSTS,                                                                                                                                                                                                                                              'failoverHostConfigs' => AUTH_FAILOVERS,                                                                                                                                                                                                                                      'connectionTimeout' => 1,                                                                                                                                                                                                                                                     'readTimeout' => 300,                                                                                                                                                                                                                                                         'maxBlackListTimeout' => 60,                                                                                                                                                                                                                                                  'logger' => $logger,                                                                                                                                                                                                                                                      ])
=> Expensify\Bedrock\Client {#441}
```