### PR TITLE
[wip]Make all Job names unique

### DIFF
--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -137,15 +137,16 @@ class Jobs extends Plugin
      * @param int|null    $parentJobID (optional) Specify this job's parent job.
      * @param string|null $connection  (optional) Specify 'Connection' header using constants defined in this class.
      * @param string|null $retryAfter  (optional) Specify after what time in RUNNING this job should be retried (same syntax as repeat)
+     * @param bool        $appendUUID  (optional) Whether the job should have a UUID appended to the name in the form of a parameter.
      *
      * @return array Containing "jobID"
      */
-    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, $retryAfter = null)
+    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, $retryAfter = null, $appendUUID = false)
     {
         $this->client->getLogger()->info("Create job", ['name' => $name]);
 
         // Add a unique identifier to job names so we can retry creating in case of network failure.
-        if (!$unique) {
+        if (!$appendUUID) {
             $name .= "?uuid=".uniqid("job", true);
         }
 
@@ -156,7 +157,7 @@ class Jobs extends Plugin
                 'data'        => $data,
                 'firstRun'    => $firstRun,
                 'repeat'      => $repeat,
-                'unique'      => true,
+                'unique'      => $unique,
                 'priority'    => $priority,
                 'parentJobID' => $parentJobID,
                 'Connection'  => $connection,

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -144,6 +144,11 @@ class Jobs extends Plugin
     {
         $this->client->getLogger()->info("Create job", ['name' => $name]);
 
+        // Add a unique identifier to job names so we can retry creating in case of network failure.
+        if (!$unique) {
+            $name .= uniqid("job", true);
+        }
+
         $response = $this->call(
             'CreateJob',
             [
@@ -151,7 +156,7 @@ class Jobs extends Plugin
                 'data'        => $data,
                 'firstRun'    => $firstRun,
                 'repeat'      => $repeat,
-                'unique'      => $unique,
+                'unique'      => true,
                 'priority'    => $priority,
                 'parentJobID' => $parentJobID,
                 'Connection'  => $connection,

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -146,7 +146,7 @@ class Jobs extends Plugin
 
         // Add a unique identifier to job names so we can retry creating in case of network failure.
         if (!$unique) {
-            $name .= uniqid("job", true);
+            $name .= "?uuid=".uniqid("job", true);
         }
 
         $response = $this->call(


### PR DESCRIPTION
As described [here](https://github.com/Expensify/Expensify/issues/66073#issuecomment-348304739) we want to be retrying all job creation if it initially fails. By adding a unique identifier to the job name, the job creation will be retried on all nodes, thus fixing a lot of errors we have where job creation fails.

This is part one of the plan laid out in the above comment.

## Fixed Issues
$ https://github.com/Expensify/Expensify/issues/66073

## Tests
WIP