### PR TITLE
Make localJobs insert synchronous

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -68,7 +68,6 @@ if ($enableLoadHandler) {
     $localDB->open();
     $query = 'CREATE TABLE IF NOT EXISTS localJobs (
         localJobID integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-        pid integer NOT NULL,
         jobID integer NOT NULL,
         jobName text NOT NULL,
         started text NOT NULL,
@@ -183,6 +182,10 @@ try {
             // in each environment looking for each path.
             $jobsToRun = $response['body']['jobs'];
             foreach ($jobsToRun as $job) {
+                if ($enableLoadHandler) {
+                    $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$job['name']}', ".microtime(true).");");
+                    $localJobID = $localDB->getLastInsertedRowID();
+                }
                 $parts = explode('/', $job['name']);
                 $jobParts = explode('?', $job['name']);
                 $extraParams = count($jobParts) > 1 ? $jobParts[1] : null;
@@ -238,17 +241,10 @@ try {
                         // that we automatically pick up new versions over the
                         // worker without needing to restart the parent.
                         include_once $workerFilename;
-                        $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrockWorker, $jobsWorker, $job, $extraParams, $logger, $localDB, $enableLoadHandler) {
+                        $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrockWorker, $jobsWorker, $job, $extraParams, $logger, $localDB, $enableLoadHandler, $localJobID) {
                             $worker = new $workerName($bedrockWorker, $job);
-                            $childPID = getmypid();
-                            $localJobID = 0;
 
                             // Open the DB connection after the fork in the child process.
-                            if ($enableLoadHandler) {
-                                $localDB->open();
-                                $localDB->write("INSERT INTO localJobs (pid, jobID, jobName, started) VALUES ($childPID, {$job['jobID']}, '{$job['name']}', ".microtime(true).");");
-                                $localJobID = $localDB->getLastInsertedRowID();
-                            }
                             try {
                                 // Run the worker.  If it completes successfully, finish the job.
                                 $worker->run();
@@ -279,7 +275,9 @@ try {
                                 $jobsWorker->failJob($job['jobID']);
                             } finally {
                                 if ($enableLoadHandler) {
+                                    $localDB->open();
                                     $localDB->write("UPDATE localJobs SET ended=".microtime(true)." WHERE localJobID=$localJobID;");
+                                    $localDB->close();
                                 }
                             }
                         });

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -182,6 +182,7 @@ try {
             // in each environment looking for each path.
             $jobsToRun = $response['body']['jobs'];
             foreach ($jobsToRun as $job) {
+                $localJobID = 0;
                 if ($enableLoadHandler) {
                     $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$job['name']}', ".microtime(true).");");
                     $localJobID = $localDB->getLastInsertedRowID();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
I added trackers into BWM and found that sometimes the inserts happen after the next call of GetJobs happens, sometimes causing us to queue more jobs than we're supposed to. Here I'm making the `insert` synchronous so we never queue more than allowed by AIMD.

```
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: R7rPW1 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER START: 9
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: xb5Q4w vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 9
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: 5jcpKx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 2
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: NJpkEG vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 3
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: x5MBtD vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 1
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: ilXJ9z vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 4
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: iLENM9 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 5
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: ozoMLQ vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 6
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: 5cCmAT vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 7
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: lReWuD vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 8
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: R7rPW1 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER START: 9
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: W7ZaM7 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 9
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: NS12xF vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 1
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: 4Op8po vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 2
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: gWRw1Y vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 3
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: rdRxYj vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 4
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: R46cst vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 5
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: llG97x vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 6
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: EOpvDD vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 7
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: R7rPW1 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER START: 4
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: AexwWI vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 8
Dec  4 23:55:11 vagrant-ubuntu-trusty-64 php: YQT8MT vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 9
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: p3Iofb vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 3
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: udRfRz vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 2
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: R7rPW1 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER START: 10
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: LoQNiH vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 1
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: IJHhc8 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 4
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: OKz5jx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 1
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: IOSkny vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 2
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: axNthZ vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 3
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: 8qd3Nh vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 4
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: XotakS vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 5
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: 4BYmzv vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 6
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: 7Yeg7l vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 7
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: m4Xxmu vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 8
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: zSxyJG vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 9
Dec  4 23:55:12 vagrant-ubuntu-trusty-64 php: l3Iucg vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] TRACKER: 10
```

# Tests
1. Comment out the `$target++` line in BWM.
2. Queue thousands of jobs
3. Run BWM
4. Grep logs for `numberOfJobsToQueue: '-`
5. Confirm that nothing ever shows up in logs