### PR TITLE
Make bwm use commitCount from the parent in the children

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -54,8 +54,6 @@ $maxSafeTime = intval($options['maxSafeTime'] ?? 0); // The maximum job time bef
 $debugThrottle = isset($options['debugThrottle']); // Set to true to maintain a debug history
 $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD load handler
 $target = $minSafeJobs;
-
-// Configure the Bedrock client with these command-line options
 $bedrock = Client::getInstance();
 
 // Prepare to use the host logger, if configured

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.1.20",
+    "version": "1.2.0",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,11 +40,11 @@ class Client implements LoggerAwareInterface
     private static $instances = [];
 
     /**
-     *  @var int The last commit count of the node we talked to. This is used to ensure if we make a subsequent
-     *           request to a different node in the same session, that the node waits until it is at least
-     *           up to date with the commits as the node we originally queried.
+     *  @var ?int The last commit count of the node we talked to. This is used to ensure if we make a subsequent
+     *            request to a different node in the same session, that the node waits until it is at least
+     *            up to date with the commits as the node we originally queried.
      */
-    public $commitCount = '';
+    public $commitCount = null;
 
     /**
      *  @var resource|null Socket to the server.

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,11 +40,11 @@ class Client implements LoggerAwareInterface
     private static $instances = [];
 
     /**
-     *  @var string The last commit count of the node we talked to. This is used to ensure if we make a subsequent
-     *              request to a different node in the same session, that the node waits until it is at least
-     *              up to date with the commits as the node we originally queried.
+     *  @var int The last commit count of the node we talked to. This is used to ensure if we make a subsequent
+     *           request to a different node in the same session, that the node waits until it is at least
+     *           up to date with the commits as the node we originally queried.
      */
-    private $commitCount = '';
+    public $commitCount = '';
 
     /**
      *  @var resource|null Socket to the server.
@@ -370,6 +370,7 @@ class Client implements LoggerAwareInterface
             'net' => $networkTime,
             'wait' => $waitTime,
             'proc' => $processingTime,
+            'commitCount' => $this->commitCount,
         ]);
 
         // Done!


### PR DESCRIPTION
@flodnv please review.

Related https://github.com/Expensify/Expensify/issues/65544
I had one queued job that when it run, it created a new job. You can see how the commitCount from GetJobs is used for the CreateJob command and the commitCount of that is used for the FinishJob command:
```
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [dbug] Bedrock\Client - Constructed ~~ clusterName: 'webrock' mainHostConfigs: '[localhost: '[port: '8888']']' failoverHostConfigs: '[localhost: '[port: '8888']']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetJobs' clusterName: 'webrock' headers: '[name: 'www-prod/*' numResults: '10' requestID: 'xZMKv0' lastIP: '' writeConsistency: 'ASYNC']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - APC fetch host configs
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - APC store host configs ~~ 0: 'localhost'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'webrock' pid: '31650'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Request finished ~~ host: 'localhost' command: 'GetJobs' jsonCode: '200 OK' duration: '0' net: '-12400' wait: '9065' proc: '3335' commitCount: '18075'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetJobs' clusterName: 'webrock' headers: '[name: 'www-prod/*' numResults: '10' commitCount: '18075' requestID: 'xZMKv0' lastIP: '' writeConsistency: 'ASYNC']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'localhost'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'localhost' cluster: 'webrock' pid: '31650'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Request finished ~~ host: 'localhost' command: 'GetJobs' jsonCode: '404 No job found' duration: '0' net: '-2922' wait: '2922' proc: '0' commitCount: '18075'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: xZMKv0 vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [dbug] Bedrock\Client - Constructed ~~ clusterName: 'webrock' mainHostConfigs: '[localhost: '[port: '8888']']' failoverHostConfigs: '[localhost: '[port: '8888']']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'CreateJob' clusterName: 'webrock' headers: '[name: 'www-prod/SampleWorker' data: '' firstRun: '' repeat: '' unique: '' priority: '500' parentJobID: '' Connection: 'wait' idempotent: '' retryAfter: '' commitCount: '18075' requestID: '3xXv6k' lastIP: '' writeConsistency: 'ASYNC']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'localhost'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'webrock' pid: '31651'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Request finished ~~ host: 'localhost' command: 'CreateJob' jsonCode: '200 OK' duration: '0' net: '-5236' wait: '4226' proc: '1010' commitCount: '18076'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'FinishJob' clusterName: 'webrock' headers: '[jobID: '8256' data: '[]' idempotent: '1' commitCount: '18076' requestID: '3xXv6k' lastIP: '' writeConsistency: 'ASYNC']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'localhost'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost']'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'localhost' cluster: 'webrock' pid: '31651'
Dec  8 16:24:19 vagrant-ubuntu-trusty-64 php: 3xXv6k vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Bedrock\Client - Request finished ~~ host: 'localhost' command: 'FinishJob' jsonCode: '200 OK' duration: '0' net: '-13863' wait: '8435' proc: '5428' commitCount: '18077'
```