### PR TITLE
Add timers for different parts of BWM process

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -107,8 +107,8 @@ try {
         $iteration++;
         $logger->info("Loop iteration", ['iteration' => $iteration]);
 
-        $isFirstTry = true;
         // Step One wait for resources to free up
+        $isFirstTry = true;
         while (true) {
             $childProcesses = [];
             // Get the latest load
@@ -138,6 +138,7 @@ try {
             }
         }
 
+        // Check to see if BWM was able to get jobs on the first attempt. If not, it would add a full second each time it failed, skewing the timer numbers.
         if ($isFirstTry) {
             $stats->timer("bedrockWorkerManager.fullLoop", microtime(true) - $loopStartTime);
         }
@@ -164,9 +165,8 @@ try {
             }
         }
 
-        $loopStartTime = microtime(true);
-
         // Found a job
+        $loopStartTime = microtime(true);
         if ($response['code'] == 200) {
             // BWM jobs are '/' separated names, the last component of which
             // indicates the name of the worker to instantiate to execute this

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -418,7 +418,7 @@ function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime,
  * Note: php's filemtime results are cached, so we need to clear
  *       that cache or we'll be getting a stale modified time.
  *
- * @param Stats\StatsInterface $stats
+ * @param Expensify\Bedrock\Stats\StatsInterface $stats
  */
 function checkVersionFile(string $versionWatchFile, int $versionWatchFileTimestamp, $stats): bool
 {

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -59,9 +59,9 @@ $target = $minSafeJobs;
 $bedrock = Client::getInstance($options);
 
 // Prepare to use the host logger and stats client, if configured
-$stats = $bedrock->getStats();
 $logger = $bedrock->getLogger();
 $logger->info('Starting BedrockWorkerManager', ['maxIterations' => $maxIterations]);
+$stats = $bedrock->getStats();
 
 // Set up the database for the AIMD load handler.
 $localDB = new LocalDB($pathToDB, $logger, $stats);
@@ -118,7 +118,7 @@ try {
                 throw new Exception('are you in a chroot?  If so, please make sure /proc is mounted correctly');
             }
 
-            if ($versionWatchFile && $stats->benchmark('bedrockWorkerManager.checkVersionFile', checkVersionFile($versionWatchFile, $versionWatchFileTimestamp))) {
+            if ($versionWatchFile && $stats->benchmark('bedrockWorkerManager.checkVersionFile', function() use ($versionWatchFile, $versionWatchFileTimestamp) { return checkVersionFile($versionWatchFile, $versionWatchFileTimestamp); })) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,
@@ -128,7 +128,7 @@ try {
 
             // Check if we can fork based on the load of our webservers
             $load = sys_getloadavg()[0];
-            list($jobsToQueue, $target) = $stats->benchmark('bedrockerWorkerManager.getNumberOfJobsToQueue', getNumberOfJobsToQueue($localDB, $target, $maxSafeTime, $minSafeJobs, $enableLoadHandler, $maxJobsForSingleRun, $debugThrottle, $logger));
+            list($jobsToQueue, $target) = $stats->benchmark('bedrockerWorkerManager.getNumberOfJobsToQueue', function() use ($localDB, $target, $maxSafeTime, $minSafeJobs, $enableLoadHandler, $maxJobsForSingleRun, $debugThrottle, $logger, $stats) { return getNumberOfJobsToQueue($localDB, $target, $maxSafeTime, $minSafeJobs, $enableLoadHandler, $maxJobsForSingleRun, $debugThrottle, $logger, $stats); });
             if ($load < $maxLoad && $jobsToQueue > 0) {
                 $logger->info('Safe to start a new job, checking for more work', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 break;
@@ -146,7 +146,7 @@ try {
         // Poll the server until we successfully get a job
         $response = null;
         while (!$response) {
-            if ($versionWatchFile && checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
+            if ($versionWatchFile && $stats->benchmark('bedrockWorkerManager.checkVersionFile', function() use ($versionWatchFile, $versionWatchFileTimestamp) { return checkVersionFile($versionWatchFile, $versionWatchFileTimestamp); })) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,
@@ -193,7 +193,7 @@ try {
             foreach ($jobsToRun as $job) {
                 $localJobID = 0;
                 if ($enableLoadHandler) {
-                    $stats->benchmark('bedrockWorkerManager.db.write.insert', $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$job['name']}', ".microtime(true).");"));
+                    $stats->benchmark('bedrockWorkerManager.db.write.insert', function() use ($localDB, $job) { $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$job['name']}', ".microtime(true).");"); });
                     $localJobID = $localDB->getLastInsertedRowID();
                 }
                 $parts = explode('/', $job['name']);
@@ -221,7 +221,7 @@ try {
                         $localDB->close();
                     }
                     pcntl_signal(SIGCHLD, SIG_IGN);
-                    $pid = $stats->benchmark('bedrockWorkerManager.fork', pcntl_fork());
+                    $pid = $stats->benchmark('bedrockWorkerManager.fork', function () { return pcntl_fork(); });
                     if ($pid == -1) {
                         // Something went wrong, couldn't fork
                         $errorMessage = pcntl_strerror(pcntl_get_last_error());
@@ -251,7 +251,7 @@ try {
                         // that we automatically pick up new versions over the
                         // worker without needing to restart the parent.
                         include_once $workerFilename;
-                        $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrockWorker, $jobsWorker, $job, $extraParams, $logger, $localDB, $enableLoadHandler, $localJobID) {
+                        $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrockWorker, $jobsWorker, $job, $extraParams, $logger, $localDB, $enableLoadHandler, $localJobID, $stats) {
                             $worker = new $workerName($bedrockWorker, $job);
 
                             // Open the DB connection after the fork in the child process.
@@ -286,7 +286,7 @@ try {
                             } finally {
                                 if ($enableLoadHandler) {
                                     $localDB->open();
-                                    $stats->benchmark('bedrockWorkerManager.db.write.update', $localDB->write("UPDATE localJobs SET ended=".microtime(true)." WHERE localJobID=$localJobID;"));
+                                    $stats->benchmark('bedrockWorkerManager.db.write.update', function() use ($localDB, $localJobID) { $localDB->write("UPDATE localJobs SET ended=".microtime(true)." WHERE localJobID=$localJobID;"); });
                                     $localDB->close();
                                 }
                             }
@@ -345,7 +345,7 @@ $logger->info('Stopped BedrockWorkerManager');
  *
  * @return array First value how many jobs it is safe to queue, second is an updated $target value.
  */
-function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime, int $minSafeJobs, bool $enableLoadHandler, int $maxJobsForSingleRun, bool $debugThrottle, Psr\Log\LoggerInterface $logger): array
+function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime, int $minSafeJobs, bool $enableLoadHandler, int $maxJobsForSingleRun, bool $debugThrottle, Psr\Log\LoggerInterface $logger, $stats): array
 {
     // Allow for disabling of the load handler.
     if (!$enableLoadHandler) {
@@ -355,7 +355,7 @@ function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime,
     }
 
     // Have we hit our target job count?
-    $numActive = $stats->benchmark('bedrockWorkerManager.db.read.activeJobs', $localDB->read('SELECT COUNT(*) FROM localJobs WHERE ended IS NULL;')[0]);
+    $numActive = $stats->benchmark('bedrockWorkerManager.db.read.activeJobs', function() use ($localDB) { return $localDB->read('SELECT COUNT(*) FROM localJobs WHERE ended IS NULL;')[0]; });
     if ($numActive < $target) {
         // Still in a safe zone, don't worry about load
         $logger->info("Safe to start new job", ["numberOfJobsToQueue" => $target - $numActive, "numActive" => $numActive, "target" => $target]);
@@ -364,7 +364,7 @@ function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime,
     }
 
     // We're at or over our target; do we have enough data to evaluate the speed?
-    $numFinished = $stats->benchmark('bedrockWorkerManager.db.read.completeJobs', $localDB->read('SELECT COUNT(*) FROM localJobs WHERE ended IS NOT NULL;')[0]);
+    $numFinished = $stats->benchmark('bedrockWorkerManager.db.read.completeJobs', function() use ($localDB) { return $localDB->read('SELECT COUNT(*) FROM localJobs WHERE ended IS NOT NULL;')[0]; });
     if ($numFinished < $target * 2) {
         // Wait until we finish at least two batches of our target so we can evaluate its speed,
         // before expanding the batch.
@@ -374,9 +374,9 @@ function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime,
     }
 
     // Calculate the speed of the last 2 batches to see if we're speeding up or slowing down
-    $oldBatchTimes = $stats->benchmark('bedrockWorkerManager.db.read.oldBatchTimes', $localDB->read("SELECT ended - started FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT $target OFFSET $target;"));
+    $oldBatchTimes = $stats->benchmark('bedrockWorkerManager.db.read.oldBatchTimes', function() use ($localDB, $target) { return $localDB->read("SELECT ended - started FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT $target OFFSET $target;"); });
     $oldBatchAverageTime = array_sum($oldBatchTimes) / count($oldBatchTimes);
-    $newBatchTimes = $stats->benchmark('bedrockWorkerManager.db.read.newBatchTimes', $localDB->read("SELECT ended - started FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT $target;"));
+    $newBatchTimes = $stats->benchmark('bedrockWorkerManager.db.read.newBatchTimes', function() use ($localDB, $target) { return $localDB->read("SELECT ended - started FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT $target;"); });
     $newBatchAverageTime = array_sum($newBatchTimes) / count($newBatchTimes);
     if (($newBatchAverageTime < $maxSafeTime || $newBatchAverageTime < 1.1 * $oldBatchAverageTime) && $numActive <= $target) {
         // The new batch is going fast enough that we don't really care, or if we do care,
@@ -390,7 +390,7 @@ function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime,
         // look farther back than that and don't want to accumulate data infinitely.  However,
         // this is very useful data to keep while debugging to analyze our throttle behavior.
         if (!$debugThrottle) {
-            $stats->benchmark('bedrockWorkerManager.db.write.deleteOldJobs', $localDB->write("DELETE FROM localJobs WHERE localJobID IN (SELECT localJobID FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT -1 OFFSET $target * 2);"));
+            $stats->benchmark('bedrockWorkerManager.db.write.deleteOldJobs', function() use ($localDB, $target) { $localDB->write("DELETE FROM localJobs WHERE localJobID IN (SELECT localJobID FROM localJobs WHERE ended IS NOT NULL ORDER BY ended DESC LIMIT -1 OFFSET $target * 2);"); });
         }
 
         // Authorize one more job given that we've just increased the target by one.

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -128,7 +128,7 @@ try {
 
             // Check if we can fork based on the load of our webservers
             $load = sys_getloadavg()[0];
-            list($jobsToQueue, $target) = getNumberOfJobsToQueue($localDB, $target, $maxSafeTime, $minSafeJobs, $enableLoadHandler, $maxJobsForSingleRun, $debugThrottle, $logger);
+            list($jobsToQueue, $target) = $stats->benchmark('bedrockerWorkerManager.getNumberOfJobsToQueue', getNumberOfJobsToQueue($localDB, $target, $maxSafeTime, $minSafeJobs, $enableLoadHandler, $maxJobsForSingleRun, $debugThrottle, $logger));
             if ($load < $maxLoad && $jobsToQueue > 0) {
                 $logger->info('Safe to start a new job, checking for more work', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 break;
@@ -221,7 +221,7 @@ try {
                         $localDB->close();
                     }
                     pcntl_signal(SIGCHLD, SIG_IGN);
-                    $pid = $stats->benchmark("bedrockWorkerManager.fork", pcntl_fork());
+                    $pid = $stats->benchmark('bedrockWorkerManager.fork', pcntl_fork());
                     if ($pid == -1) {
                         // Something went wrong, couldn't fork
                         $errorMessage = pcntl_strerror(pcntl_get_last_error());

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -116,7 +116,7 @@ try {
                 throw new Exception('are you in a chroot?  If so, please make sure /proc is mounted correctly');
             }
 
-            if ($versionWatchFile && checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
+            if ($versionWatchFile && checkVersionFile($versionWatchFile, $versionWatchFileTimestamp, $stats)) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,
@@ -145,7 +145,7 @@ try {
         // Poll the server until we successfully get a job
         $response = null;
         while (!$response) {
-            if ($versionWatchFile && checkVersionFile($versionWatchFile, $versionWatchFileTimestamp)) {
+            if ($versionWatchFile && checkVersionFile($versionWatchFile, $versionWatchFileTimestamp, $stats)) {
                 $logger->info('Version watch file changed, stop processing new jobs');
 
                 // We break out of this loop and the outer one too. We don't want to process anything more,
@@ -417,8 +417,10 @@ function getNumberOfJobsToQueue(LocalDB $localDB, int $target, int $maxSafeTime,
  *
  * Note: php's filemtime results are cached, so we need to clear
  *       that cache or we'll be getting a stale modified time.
+ *
+ * @param Stats\StatsInterface $stats
  */
-function checkVersionFile(string $versionWatchFile, int $versionWatchFileTimestamp): bool
+function checkVersionFile(string $versionWatchFile, int $versionWatchFileTimestamp, $stats): bool
 {
     return $stats->benchmark('bedrockWorkerManager.checkVersionFile', function () use ($versionWatchFile, $versionWatchFileTimestamp) {
         clearstatcache(true, $versionWatchFile);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "authors": [
         {
             "name": "Expensify",

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -22,8 +22,13 @@ class LocalDB
     /** @var LoggerInterface $logger */
     private $logger;
 
+    /** @var Stats\StatsInterface */
+    private $stats;
+
     /**
      * Creates a localDB object and sets the file location.
+     *
+     * @param Stats\StatsInterface $stats
      */
     public function __construct(string $location, LoggerInterface $logger, $stats)
     {
@@ -35,7 +40,8 @@ class LocalDB
     /**
      * Opens a DB connection.
      */
-    public function open() {
+    public function open()
+    {
         if (!isset($this->handle)) {
             $startTime = microtime(true);
             $this->handle = new SQLite3($this->location);
@@ -66,7 +72,7 @@ class LocalDB
     public function read(string $query)
     {
         $result = null;
-        while(true) {
+        while (true) {
             try {
                 $result = $this->handle->query($query);
                 break;
@@ -92,7 +98,7 @@ class LocalDB
      */
     public function write(string $query)
     {
-        while(true) {
+        while (true) {
             try {
                 $this->handle->query($query);
                 break;

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -43,7 +43,7 @@ class LocalDB
     public function open()
     {
         if (!isset($this->handle)) {
-            $this->stats->benchmark('bedrockWorkerManager.db.open', function() {
+            $this->stats->benchmark('bedrockWorkerManager.db.open', function () {
                 $this->handle = new SQLite3($this->location);
                 $this->handle->busyTimeout(15000);
                 $this->handle->enableExceptions(true);
@@ -57,7 +57,7 @@ class LocalDB
     public function close()
     {
         if (isset($this->handle)) {
-            $this->stats->benchmark('bedrockWorkerManager.db.close', function() {
+            $this->stats->benchmark('bedrockWorkerManager.db.close', function () {
                 $startTime = microtime(true);
                 $this->handle->close();
                 unset($this->handle);
@@ -68,11 +68,12 @@ class LocalDB
     /**
      * Runs a read query on a local database.
      *
-     * @return array|null
+     * @return array
      */
     public function read(string $query)
     {
         $result = null;
+        $returnValue = [];
         while (true) {
             try {
                 $result = $this->handle->query($query);
@@ -91,7 +92,7 @@ class LocalDB
             $returnValue = $result->fetchArray(SQLITE3_NUM);
         }
 
-        return $returnValue ?? null;
+        return $returnValue;
     }
 
     /**

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -92,7 +92,7 @@ class LocalDB
             $returnValue = $result->fetchArray(SQLITE3_NUM);
         }
 
-        return $returnValue;
+        return $returnValue ?? [];
     }
 
     /**

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Expensify\Bedrock;
 
 use Exception;
-use Expensify\Bedrock\Stats\StatsInterface;
 use Psr\Log\LoggerInterface;
 use SQLite3;
 
@@ -26,7 +25,7 @@ class LocalDB
     /**
      * Creates a localDB object and sets the file location.
      */
-    public function __construct(string $location, LoggerInterface $logger, StatsInterface $stats)
+    public function __construct(string $location, LoggerInterface $logger, $stats)
     {
         $this->location = $location;
         $this->logger = $logger;

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -68,12 +68,12 @@ class LocalDB
     /**
      * Runs a read query on a local database.
      *
-     * @return array
+     * @return ?array
      */
     public function read(string $query)
     {
         $result = null;
-        $returnValue = [];
+        $returnValue = null;
         while (true) {
             try {
                 $result = $this->handle->query($query);
@@ -92,7 +92,7 @@ class LocalDB
             $returnValue = $result->fetchArray(SQLITE3_NUM);
         }
 
-        return $returnValue ?? [];
+        return $returnValue;
     }
 
     /**

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -68,12 +68,12 @@ class LocalDB
     /**
      * Runs a read query on a local database.
      *
-     * @return ?array
+     * @return array
      */
     public function read(string $query)
     {
         $result = null;
-        $returnValue = null;
+        $returnValue = [];
         while (true) {
             try {
                 $result = $this->handle->query($query);
@@ -92,7 +92,7 @@ class LocalDB
             $returnValue = $result->fetchArray(SQLITE3_NUM);
         }
 
-        return $returnValue;
+        return $returnValue ?? [];
     }
 
     /**

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -72,6 +72,7 @@ class LocalDB
     public function read(string $query)
     {
         $result = null;
+        $returnValue = null;
         while (true) {
             try {
                 $result = $this->handle->query($query);

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -43,11 +43,11 @@ class LocalDB
     public function open()
     {
         if (!isset($this->handle)) {
-            $startTime = microtime(true);
-            $this->handle = new SQLite3($this->location);
-            $this->handle->busyTimeout(15000);
-            $this->handle->enableExceptions(true);
-            $this->stats->timer('bedrockWorkerManager.db.open', microtime(true) - $startTime);
+            $this->stats->benchmark('bedrockWorkerManager.db.open', function() {
+                $this->handle = new SQLite3($this->location);
+                $this->handle->busyTimeout(15000);
+                $this->handle->enableExceptions(true);
+            });
         }
     }
 
@@ -57,10 +57,11 @@ class LocalDB
     public function close()
     {
         if (isset($this->handle)) {
-            $startTime = microtime(true);
-            $this->handle->close();
-            unset($this->handle);
-            $this->stats->timer('bedrockWorkerManager.db.close', microtime(true) - $startTime);
+            $this->stats->benchmark('bedrockWorkerManager.db.close', function() {
+                $startTime = microtime(true);
+                $this->handle->close();
+                unset($this->handle);
+            });
         }
     }
 
@@ -72,7 +73,6 @@ class LocalDB
     public function read(string $query)
     {
         $result = null;
-        $returnValue = null;
         while (true) {
             try {
                 $result = $this->handle->query($query);


### PR DESCRIPTION
Hold for packaging.

I added timers that get sent to StatsD to help us evaluate how well BWM is performing.

Related: https://github.com/Expensify/Expensify/issues/61961

#### Timers added
* Full loop (excluding GetJobs)
* CheckVersionFile
* GetNumberOfJobsToQueue
* Insert into localJobsDB
* Read from localJobsDB
* Delete from localJobsDB
* Update localJobsDB
* Fork
* Opening the DB
* Closing the DB

#### Counters added
* Target

### Tests
1. Run BWM with --enableLoadHandler and make sure it runs with no warns or errors.

No QA