### PR TITLE
[HOLD discussion] Replace bad ascii with characters rather than deleting them.

### DIFF
--- a/ci/src/PHPStyler.php
+++ b/ci/src/PHPStyler.php
@@ -61,7 +61,7 @@ class PHPStyler extends CommandLine
         foreach ($output as $file) {
             echo "Linting $file... ".PHP_EOL;
 
-            $fixerCmd = "$dir/lib/tools/php-style-fixer fix --diff $file";
+            $fixerCmd = "$dir/../vendor/bin/php-style-fixer fix --diff $file";
             $fileResult = $this->eexec($fixerCmd, true);
             $fileOK = true;
             foreach ($fileResult as $index => $line) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -588,7 +588,7 @@ class Client implements LoggerAwareInterface
             // This will remove unwanted characters.
             // Check http://stackoverflow.com/a/20845642 and http://www.php.net/chr for details
             for ($i = 0; $i <= 31; $i++) {
-                $body = str_replace(chr($i), '', $body);
+                $body = str_replace(chr($i), '#'.$i, $body);
             }
             $jsonStr = str_replace(chr(127), '', $body);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -588,7 +588,7 @@ class Client implements LoggerAwareInterface
             // This will remove unwanted characters.
             // Check http://stackoverflow.com/a/20845642 and http://www.php.net/chr for details
             for ($i = 0; $i <= 31; $i++) {
-                $body = str_replace(chr($i), '#'.$i, $body);
+                $body = str_replace(chr($i), "#$i", $body);
             }
             $jsonStr = str_replace(chr(127), '', $body);
 


### PR DESCRIPTION
cc: @coleaeason 

Before we would purge bad ascii when receiving requests. I tested this with our `#001private_amountOwed` NVP stored in the DB. We shouldn't purge bad ascii or else we change it to `private_amountOwed` which then is valid... which is bad. 

Right now I set it to replace the bad ascii to the ascii code itself, prepended with a `#`. So `#001private_amountOwed` => `#1private_amountOwed`
