### PR TITLE
Do not fail BWM if we retried a command

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Expensify\Bedrock\Client;
+use Expensify\Bedrock\Exceptions\Jobs\DoesNotExist;
+use Expensify\Bedrock\Exceptions\Jobs\IllegalAction;
 use Expensify\Bedrock\Exceptions\Jobs\RetryableException;
 use Expensify\Bedrock\Jobs;
 use Expensify\Bedrock\LocalDB;
@@ -269,7 +271,17 @@ try {
                                     'id' => $job['jobID'],
                                     'extraParams' => $extraParams,
                                 ]);
-                                $jobs->finishJob($job['jobID'], $worker->getData());
+                                try {
+                                    $jobs->finishJob($job['jobID'], $worker->getData());
+                                } catch (DoesNotExist $e) {
+                                    // Job does not exist, but we know it had to exist because we were running it, so
+                                    // we assume this is happening because we retried the command in a different server.
+                                    $logger->info('Failed to FinishJob we probably retried the command so it is safe to ignore', ['job' => $job, 'exception' => $e]);
+                                } catch (IllegalAction $e) {
+                                    // IllegalAction is returned when we try to finish a job not in RUNNING state, which
+                                    // can happen if we retried the command in a different server.
+                                    $logger->info('Failed to FinishJob we probably retried the command on a child job so it is safe to ignore', ['job' => $job, 'exception' => $e]);
+                                }
                             } catch (RetryableException $e) {
                                 // Worker had a recoverable failure; retry again later.
                                 $logger->info("Job could not complete, retrying.", [
@@ -277,7 +289,13 @@ try {
                                     'id' => $job['jobID'],
                                     'extraParams' => $extraParams,
                                 ]);
-                                $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
+                                try {
+                                    $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
+                                } catch (IllegalAction $e) {
+                                     // IllegalAction is returned when we try to finish a job that's not RUNNING, this
+                                    // can happen if we retried the command in a different server.
+                                    $logger->info('Failed to RetryJob we probably retried the command so it is safe to ignore', ['job' => $job, 'exception' => $e]);
+                                }
                             } catch (Throwable $e) {
                                 $logger->alert("Job failed with errors, exiting.", [
                                     'name' => $job['name'],
@@ -286,7 +304,13 @@ try {
                                     'exception' => $e,
                                 ]);
                                 // Worker had a fatal error -- mark as failed.
-                                $jobs->failJob($job['jobID']);
+                                try {
+                                    $jobs->failJob($job['jobID']);
+                                } catch (IllegalAction $e) {
+                                    // IllegalAction is returned when we try to finish a job that's not RUNNING, this
+                                    // can happen if we retried the command in a different server.
+                                    $logger->info('Failed to FailJob we probably retried a repeat command so it is safe to ignore', ['job' => $job, 'exception' => $e]);
+                                }
                             } finally {
                                 if ($enableLoadHandler) {
                                     $localDB->open();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Needed for https://github.com/Expensify/Expensify/issues/69511

Tested by throwing manually right after `$this->receiveResponse()` in `Client` with code similar to (adapting the method for each test):
```
                if ($hostName === 'localhost' && $method === 'FinishJob') {
                    $response = null;
                    throw new BedrockError('Pepe');
                }
```
I have `localhost` as the main host and `127.0.0.1` as failover, so this means it will fail the first time (but after actually running the command) and retry.

Finishing a normal job:

```
Bedrock\Client - Starting a request ~~ command: 'FinishJob' clusterName: 'webrock' headers: '[jobID: '8540' data: '[]' idempotent: '1' commitCount: '18459' requestID: 'XtAf8Z' lastIP: '' writeConsistency: 'ASYNC']'
Bedrock\Client - APC fetch host configs ~~ 0: 'localhost' 1: '127.0.0.1'
Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost' 1: '127.0.0.1']'
Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'webrock' pid: '10747'
Bedrock\Client - Marking server as failed ~~ host: 'localhost' time: '2018-02-16 15:47:20'
Bedrock\Client - Failed to send the whole request or to receive it; retrying because command is idempotent ~~ host: 'localhost' message: 'Pepe' retriesLeft: '1' exception: 'Expensify\Bedrock\Exceptions\BedrockError: Pepe in /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Client.php:332#012Stack trace:#012#0 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php(97): Expensify\Bedrock\Client->call('FinishJob', Array, '')#012#1 /vagrant/Web-Expensify/lib/StatsD.php(348): Expensify\Bedrock\Jobs->Expensify\Bedrock\{closure}()#012#2 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php(98): StatsD::benchmark('bedrock.jobs.Fi...', Object(Closure))#012#3 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php(266): Expensify\Bedrock\Jobs->call('FinishJob', Array)#012#4 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(277): Expensify\Bedrock\Jobs->finishJob(8540, Array)#012#5 /vagrant/Web-Expensify/lib/StatsD.php(348): {closure}()#012#6 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(337): StatsD::benchmark('bedrockJob.fini...', Object(Closure))#012#7 {main}'
Bedrock\Client - Opening new socket ~~ host: '127.0.0.1' cluster: 'webrock' pid: '10747'
Bedrock\Client - Request finished ~~ host: '127.0.0.1' command: 'FinishJob' jsonCode: '404 No job with this jobID' duration: '0' net: '-2573' wait: '143' proc: '2430' commitCount: '18460'
Failed to FinishJob we probably retried the command so it is safe to ignore ~~ job: '[created: '2018-02-16 15:46:20' data: '[]' jobID: '8540' name: 'www-prod/SampleWorker']' exception: 'Expensify\Bedrock\Exceptions\Jobs\DoesNotExist: Job 8540 does not exist in /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php:111#012Stack trace:#012#0 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php(266): Expensify\Bedrock\Jobs->call('FinishJob', Array)#012#1 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(277): Expensify\Bedrock\Jobs->finishJob(8540, Array)#012#2 /vagrant/Web-Expensify/lib/StatsD.php(348): {closure}()#012#3 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(337): StatsD::benchmark('bedrockJob.fini...', Object(Closure))#012#4 {main}'
```

Finishing a job that's a child:
```
Bedrock\Client - Starting a request ~~ command: 'FinishJob' clusterName: 'webrock' headers: '[jobID: '8547' data: '[isParent: '']' idempotent: '1' commitCount: '18480' requestID: '0tTZ0v' lastIP: '' writeConsistency: 'ASYNC']'
Bedrock\Client - APC fetch host configs ~~ 0: 'localhost' 1: '127.0.0.1'
Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost' 1: '127.0.0.1']'
Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'webrock' pid: '12257'
Bedrock\Client - Marking server as failed ~~ host: 'localhost' time: '2018-02-16 16:06:35'
Bedrock\Client - Failed to send the whole request or to receive it; retrying because command is idempotent ~~ host: 'localhost' message: 'Pepe' retriesLeft: '1' exception: ...
Bedrock\Client - Opening new socket ~~ host: '127.0.0.1' cluster: 'webrock' pid: '12257'
Bedrock\Client - Request finished ~~ host: '127.0.0.1' command: 'FinishJob' jsonCode: '405 Can only retry/finish RUNNING and RUNQUEUED jobs' duration: '0' net: '-2345' wait: '126' proc: '2219' commitCount: '18481'
Failed to FinishJob we probably retried the command on a child job so it is safe to ignore ~~ job: '[created: '2018-02-16 16:05:20' data: '[isParent: '']' jobID: '8547' name: 'www-prod/SampleWorker' parentData: '[isParent: '1']' parentJobID: '8546']' exception: 'Expensify\Bedrock\Exceptions\Jobs\IllegalAction: Cannot perform `FinishJob` on job 8547 in /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php:115#012Stack trace:#012#0 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php(262): Expensify\Bedrock\Jobs->call('FinishJob', Array)#012#1 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(277): Expensify\Bedrock\Jobs->finishJob(8547, Array)#012#2 /vagrant/Web-Expensify/lib/StatsD.php(348): {closure}()#012#3 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(336): StatsD::benchmark('bedrockJob.fini...', Object(Closure))#012#4 {main}'
```

Retrying the job:
```
Job could not complete, retrying. ~~ name: 'www-prod/SampleWorker' id: '8548' extraParams: ''
Bedrock\Client - Starting a request ~~ command: 'RetryJob' clusterName: 'webrock' headers: '[jobID: '8548' delay: '0' data: '[]' name: '' nextRun: '' idempotent: '1' commitCount: '18483' requestID: 'PyIfnp' lastIP: '' writeConsistency: 'ASYNC']'
Bedrock\Client - APC fetch host configs ~~ 0: 'localhost' 1: '127.0.0.1'
Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost' 1: '127.0.0.1']'
Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'webrock' pid: '12489'
Bedrock\Client - Marking server as failed ~~ host: 'localhost' time: '2018-02-16 16:13:49'
Bedrock\Client - Failed to send the whole request or to receive it; retrying because command is idempotent ~~ host: 'localhost' message: 'Pepe' retriesLeft: '1' exception: ...
Bedrock\Client - Opening new socket ~~ host: '127.0.0.1' cluster: 'webrock' pid: '12489'
Bedrock\Client - Request finished ~~ host: '127.0.0.1' command: 'RetryJob' jsonCode: '405 Can only retry/finish RUNNING and RUNQUEUED jobs' duration: '0' net: '-2572' wait: '126' proc: '2446' commitCount: '18484'
Failed to RetryJob we probably retried the command so it is safe to ignore ~~ job: '[created: '2018-02-16 16:13:08' data: '[]' jobID: '8548' name: 'www-prod/SampleWorker']' exception: 'Expensify\Bedrock\Exceptions\Jobs\IllegalAction: Cannot perform `RetryJob` on job  in /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php:115#012Stack trace:#012#0 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php(330): Expensify\Bedrock\Jobs->call('RetryJob', Array)#012#1 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(295): Expensify\Bedrock\Jobs->retryJob(8548, 0, Array, '', '')#012#2 /vagrant/Web-Expensify/lib/StatsD.php(348): {closure}()#012#3 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(336): StatsD::benchmark('bedrockJob.fini...', Object(Closure))#012#4 {main}'

```

Fail job:
```
ENSURE_BUGBOT www-prod/SampleWorker Job failed with errors, exiting. ~~ name: 'www-prod/SampleWorker' id: '8550' extraParams: '' exception: 'Exception: ...
Problem getting job, retrying in 60s ~~ message: 'Job www-prod/* does not exist'
Bedrock\Client - Starting a request ~~ command: 'FailJob' clusterName: 'webrock' headers: '[jobID: '8550' idempotent: '1' commitCount: '18491' requestID: 'CnV8xr' lastIP: '' writeConsistency: 'ASYNC']'
Bedrock\Client - APC fetch host configs ~~ 0: 'localhost' 1: '127.0.0.1'
Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost' 1: '127.0.0.1']'
Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'webrock' pid: '12981'
Bedrock\Client - Marking server as failed ~~ host: 'localhost' time: '2018-02-16 16:19:53'
Bedrock\Client - Failed to send the whole request or to receive it; retrying because command is idempotent ~~ host: 'localhost' message: 'Pepe' retriesLeft: '1' exception: ...
Bedrock\Client - Opening new socket ~~ host: '127.0.0.1' cluster: 'webrock' pid: '12981'
Bedrock\Client - Request finished ~~ host: '127.0.0.1' command: 'FailJob' jsonCode: '405 Can only fail RUNNING jobs' duration: '0' net: '-2664' wait: '131' proc: '2533' commitCount: '18492'
Failed to FailJob we probably retried a repeat command so it is safe to ignore ~~ job: '[created: '2018-02-16 16:16:46' data: '[]' jobID: '8550' name: 'www-prod/SampleWorker']' exception: 'Expensify\Bedrock\Exceptions\Jobs\IllegalAction: Cannot perform `FailJob` on job 8550 in /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php:115#012Stack trace:#012#0 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/src/Jobs.php(316): Expensify\Bedrock\Jobs->call('FailJob', Array)#012#1 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(310): Expensify\Bedrock\Jobs->failJob(8550)#012#2 /vagrant/Web-Expensify/lib/StatsD.php(348): {closure}()#012#3 /vagrant/Web-Expensify/vendor/expensify/Bedrock-PHP/bin/BedrockWorkerManager.php(332): StatsD::benchmark('bedrockJob.fini...', Object(Closure))#012#4 {main}'

```