### PR TITLE
Protect against sql injecting ourselves

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -194,11 +194,10 @@ try {
             $jobsToRun = $response['body']['jobs'];
             foreach ($jobsToRun as $job) {
                 $localJobID = 0;
-                $safeJobID = SQLite3::escapeString($job['jobID']);
                 $safeJobName = SQLite3::escapeString($job['name']);
                 if ($enableLoadHandler) {
                     $stats->benchmark('bedrockWorkerManager.db.write.insert', function () use ($localDB, $job) {
-                        $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$safeJobID}, '{$safeJobName}', ".microtime(true).");");
+                        $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$safeJobName}', ".microtime(true).");");
                     });
                     $localJobID = $localDB->getLastInsertedRowID();
                 }

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -194,8 +194,8 @@ try {
             $jobsToRun = $response['body']['jobs'];
             foreach ($jobsToRun as $job) {
                 $localJobID = 0;
-                $safeJobName = SQLite3::escapeString($job['name']);
                 if ($enableLoadHandler) {
+                    $safeJobName = SQLite3::escapeString($job['name']);
                     $stats->benchmark('bedrockWorkerManager.db.write.insert', function () use ($localDB, $job, $safeJobName) {
                         $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$safeJobName}', ".microtime(true).");");
                     });

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -194,8 +194,12 @@ try {
             $jobsToRun = $response['body']['jobs'];
             foreach ($jobsToRun as $job) {
                 $localJobID = 0;
+                $safeJobID = SQLite3::escapeString($job['jobID']);
+                $safeJobName = SQLite3::escapeString($job['name']);
                 if ($enableLoadHandler) {
-                    $stats->benchmark('bedrockWorkerManager.db.write.insert', function () use ($localDB, $job) { $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$job['name']}', ".microtime(true).");"); });
+                    $stats->benchmark('bedrockWorkerManager.db.write.insert', function () use ($localDB, $job) {
+                        $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$safeJobID}, '{$safeJobName}', ".microtime(true).");");
+                    });
                     $localJobID = $localDB->getLastInsertedRowID();
                 }
                 $parts = explode('/', $job['name']);

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -196,7 +196,7 @@ try {
                 $localJobID = 0;
                 $safeJobName = SQLite3::escapeString($job['name']);
                 if ($enableLoadHandler) {
-                    $stats->benchmark('bedrockWorkerManager.db.write.insert', function () use ($localDB, $job) {
+                    $stats->benchmark('bedrockWorkerManager.db.write.insert', function () use ($localDB, $job, $safeJobName) {
                         $localDB->write("INSERT INTO localJobs (jobID, jobName, started) VALUES ({$job['jobID']}, '{$safeJobName}', ".microtime(true).");");
                     });
                     $localJobID = $localDB->getLastInsertedRowID();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Emails have special characters in them, and it was allowing us to sql inject ourselves in the BWM db.

Related to: https://github.com/Expensify/Expensify/issues/66022

HOLD for updating version

# Tests
1. Queue job with special characters in the params (i.e. `www-prod/TestJob?asdf=''''`)
2. Run BWM
3. Confirm that it doesn't crash and is inserted into the db effectively.
```
3|66|www-prod/TestJob?asdf=''''f'|1520450955.5|1520450955.62
```