### PR TITLE
Instrument cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.2.9",
+    "version": "1.3.0",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -72,6 +72,7 @@ class Cache extends Plugin
      * Call the bedrock cache methods, and handle connection error.
      *
      * @param string $body
+     *
      * @return mixed|null
      */
     private function call(string $method, array $headers, $body = '')


### PR DESCRIPTION
@fnwbr please review.

Tests:
- We have some automated tests in the web repo.
- Tested:
```
➜  Web-Expensify git:(staging) ✗ ../script/psysh.sh
Psy Shell v0.8.1 (PHP 7.0.28-1+ubuntu14.04.1+deb.sury.org+1 — cli) by Justin Hileman
New version is available (current: v0.8.1, latest: v0.8.17)
>>> $c = new Expensify\Bedrock\Cache(Expensify\Bedrock\Client::getInstance())
=> Expensify\Bedrock\Cache {#388}
>>> $c->write('something', '["uno"]')
=> [
     "headers" => [
       "Content-Length" => "0",
     ],
     "body" => [],
     "size" => 46,
     "codeLine" => "202 Successfully queued",
     "code" => 202,
   ]
>>> $c->read('something')
=> [
     "headers" => [
       "commitCount" => "19",
       "name" => "something/",
       "nodeName" => "bedrock",
       "peekTime" => "3764",
       "totalTime" => "3874",
       "unaccountedTime" => "80",
       "Content-Length" => "7",
     ],
     "body" => [
       "uno",
     ],
     "size" => 139,
     "codeLine" => "200 OK",
     "code" => 200,
   ]
```