### PR TITLE
Allow to pass preferred host

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -307,7 +307,23 @@ class Client implements LoggerAwareInterface
         $rawRequest .= $body;
 
         $response = null;
-        $hostConfigs = $this->getPossibleHosts();
+        $preferredHost = null;
+        if (isset($headers['host'])) {
+            $preferredHost = $headers['host'];
+            unset($headers['host']);
+        }
+        $hostConfigs = $this->getPossibleHosts($preferredHost);
+
+        // If we passed a preferred host and we already had a connected socket, but to a different host and the preferred
+        // host is not blacklisted (the preferred host is returned first in the possible hosts array only when it's not blacklisted)
+        // then we close the socket in order to connect to the preferred one.
+        $closeSocketAfterRequest = false;
+        if ($preferredHost && $this->socket && key($hostConfigs) !== $this->lastHost) {
+            @socket_close($this->socket);
+            $this->socket = null;
+            $closeSocketAfterRequest = true;
+        }
+
         $hostName = null;
         while (!$response && count($hostConfigs)) {
             reset($hostConfigs);
@@ -354,6 +370,12 @@ class Client implements LoggerAwareInterface
 
         if (is_null($response)) {
             throw new ConnectionFailure('Could not connect to Bedrock hosts or failovers');
+        }
+
+        // If we connected to a preferred host, disconnect from it so we don't send all future requests to it.
+        if ($closeSocketAfterRequest) {
+            @socket_close($this->socket);
+            $this->socket = null;
         }
 
         // Log how long this particular call took
@@ -433,9 +455,11 @@ class Client implements LoggerAwareInterface
     }
 
     /**
+     * @param ?string $preferredHost If passed, it will prefer this host over any of the configured ones. This does not
+     *                               ensure it will use that host, but it will try to use it if its not blacklisted.
      * @suppress PhanUndeclaredConstant - suppresses TRAVIS_RUNNING
      */
-    private function getPossibleHosts()
+    private function getPossibleHosts(string $preferredHost = null)
     {
         // We get the host configs from the APC cache. Then, we check the configuration there with the passed
         // configuration and if it's outdated (ie: it has different hosts from the one in the config), we reset it. This
@@ -475,7 +499,7 @@ class Client implements LoggerAwareInterface
         $failoverHostNames = array_keys($this->failoverHostConfigs);
         shuffle($failoverHostNames);
         $mainHostName = array_rand($this->mainHostConfigs);
-        $hostNames = array_merge([$mainHostName], $failoverHostNames);
+        $hostNames = array_unique(array_merge($preferredHost ? [$preferredHost] : [], [$mainHostName], $failoverHostNames));
 
         $nonBlackListedHosts = [];
         foreach ($hostNames as $hostName) {


### PR DESCRIPTION
@flodnv please review.

Tests:
With this auth config:
```
define('AUTH_HOSTS', ['auth' => ['port' => 4444]]);
define('AUTH_FAILOVERS', ['auth' => ['port' => 4444], 'localhost' => ['port' => 4444]]);
```
and this script:
```
Auth::call('Get', ['returnValueList' => 'account', 'authToken' => $authToken]);
Auth::call('SetNameValuePair', ['name' => 'caca', 'value' => 'caca', 'authToken' => $authToken, 'host' => 'localhost']);
Auth::call('Get', ['returnValueList' => 'account', 'authToken' => $authToken]);
```

Check that it used the correct host for each request (so, first `auth`, then `localhost`, then `auth` again). And check the `commitCount` was preserved across calls.
```
Apr 10 14:01:51 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [dbug] Bedrock\Client - Constructed ~~ clusterName: 'auth' mainHostConfigs: '[auth: '[port: '4444']']' failoverHostConfigs: '[auth: '[port: '4444']' localhost: '[port: '4444']']'
Apr 10 14:01:51 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'Get' clusterName: 'auth' headers: '[returnValueList: 'account' requestID: 'xA82YN' lastIP: '10.2.2.1' writeConsistency: 'ASYNC']'
Apr 10 14:01:53 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth' 1: 'localhost'
Apr 10 14:01:53 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth' 1: 'localhost']'
Apr 10 14:01:56 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Opening new socket ~~ host: 'auth' cluster: 'auth' pid: '23961'
Apr 10 14:01:56 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'Get' jsonCode: '200 OK' duration: '5.497' net: '-5048.503' wait: '5054' proc: '0' commitCount: '38939'
Apr 10 14:01:56 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'SetNameValuePair' clusterName: 'auth' headers: '[name: 'caca' value: 'caca' host: 'localhost' commitCount: '38939' requestID: 'xA82YN' lastIP: '10.2.2.1' writeConsistency: 'ASYNC']'
Apr 10 14:01:57 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth' 1: 'localhost'
Apr 10 14:01:57 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost' 1: 'auth']'
Apr 10 14:02:02 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'auth' pid: '23961'
Apr 10 14:02:02 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'localhost' command: 'SetNameValuePair' jsonCode: '200 OK' duration: '6.012' net: '-18203.988' wait: '16178' proc: '2032' commitCount: '38940'
Apr 10 14:02:02 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'Get' clusterName: 'auth' headers: '[returnValueList: 'account' commitCount: '38940' requestID: 'xA82YN' lastIP: '10.2.2.1' writeConsistency: 'ASYNC']'
Apr 10 14:02:03 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth' 1: 'localhost'
Apr 10 14:02:03 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth' 1: 'localhost']'
Apr 10 14:02:08 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Opening new socket ~~ host: 'auth' cluster: 'auth' pid: '23961'
Apr 10 14:02:08 vagrant-ubuntu-trusty-64 php-cgi: xA82YN /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'Get' jsonCode: '200 OK' duration: '6.191' net: '-10958.809' wait: '10965' proc: '0' commitCount: '38940'
```