### PR TITLE
Track stats for db plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "authors": [
         {
             "name": "Expensify",

--- a/src/DB.php
+++ b/src/DB.php
@@ -48,8 +48,6 @@ class DB extends Plugin
      * @param bool   $idempotent Is this command idempotent? If the command is run twice is the final result the same?
      * @param int    $timeout    Time in microseconds, defaults to 60 seconds
      *
-     * @return array
-     *
      * @throws BedrockError
      */
     public function run(string $sql, bool $idempotent, int $timeout = 60000000): Response

--- a/src/DB.php
+++ b/src/DB.php
@@ -49,6 +49,7 @@ class DB extends Plugin
      * @param int    $timeout    Time in microseconds, defaults to 60 seconds
      *
      * @return array
+     *
      * @throws BedrockError
      */
     public function run(string $sql, bool $idempotent, int $timeout = 60000000): Response


### PR DESCRIPTION
@mea36 please review.

Related https://github.com/Expensify/Expensify/issues/77283

Tests:
```
$db = new Expensify\Bedrock\DB(Expensify\Bedrock\Client::getInstance());
try {
    $db->run('seleCt * fRom something as algo where a = 1', true);
} catch (Throwable $e) {}
try {
    $db->run('select a,b,c fRom something as algo inner join other on algo.a = other.b where a = 1', true);
} catch (Throwable $e) {}
try {
    $db->run('SELECT distinct a.a fRom something as algo inner join other on algo.a = other.b where a = 1 order by a group by c offset 1 limit 10;', true);
} catch (Throwable $e) {}
try {
    $db->run('INSERT into table (one, two, three) VALUES (1,2,3), (3,4,5);', true);
} catch (Throwable $e) {}
try {
    $db->run('UPDATE table set algo = 1, other = "string" WHERE field=true limit 100;', true);
} catch (Throwable $e) {}
try {
    $db->run('DELETE from table where a = 2;', true);
} catch (Throwable $e) {}
```
Output:
```
Apr 17 16:29:08 vagrant-ubuntu-trusty-64 php-cgi: uSudLJ /caca.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( vagrant-ubuntu-trusty-64.web.bedrock.db.query.select:2|ms )
Apr 17 16:29:08 vagrant-ubuntu-trusty-64 php-cgi: uSudLJ /caca.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( vagrant-ubuntu-trusty-64.web.bedrock.db.query.select:2|ms )
Apr 17 16:29:08 vagrant-ubuntu-trusty-64 php-cgi: uSudLJ /caca.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( vagrant-ubuntu-trusty-64.web.bedrock.db.query.select:2|ms )
Apr 17 16:29:08 vagrant-ubuntu-trusty-64 php-cgi: uSudLJ /caca.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( vagrant-ubuntu-trusty-64.web.bedrock.db.query.insert:2|ms )
Apr 17 16:29:08 vagrant-ubuntu-trusty-64 php-cgi: uSudLJ /caca.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( vagrant-ubuntu-trusty-64.web.bedrock.db.query.update:2|ms )
Apr 17 16:29:08 vagrant-ubuntu-trusty-64 php-cgi: uSudLJ /caca.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( vagrant-ubuntu-trusty-64.web.bedrock.db.query.delete:2|ms )
```