### PR TITLE
Sleep after starting some jobs

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -355,7 +355,7 @@ try {
                     $jobs->failJob($job['jobID']);
                 }
             }
-            // After starting a few jobs, wait for a couple of seconds to give time to some jobs to finish so its more
+            // After starting a few jobs, wait for a couple of seconds to give time to some jobs to finish so it's more
             // likely that we retrieve a higher number of jobs per GetJobs call.
             sleep(2);
         } elseif ($response['code'] == 303) {

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -355,6 +355,9 @@ try {
                     $jobs->failJob($job['jobID']);
                 }
             }
+            // After starting a few jobs, wait for a couple of seconds to give time to some jobs to finish so its more
+            // likely that we retrieve a higher number of jobs per GetJobs call.
+            sleep(2);
         } elseif ($response['code'] == 303) {
             $logger->info("No job found, retrying.");
         } else {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/77430

We use GetJobs to try to dequeue several jobs in the same call, but since we are calling it immediately after starting all jobs, we usually end up retrieving very few jobs per call because the jobs did not have time to finish yet. By adding a sleep we hope to make the GetJobs calls to retrieve more jobs per run, which in turn reduces the possibilities of the command conflicting.