### PR TITLE
Fix preferred host when host doesn't exist in the configs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -521,7 +521,7 @@ class Client implements LoggerAwareInterface
         shuffle($failoverHostNames);
         $mainHostName = array_rand($this->mainHostConfigs);
         $preferredHost = in_array($preferredHost, $cachedHostConfigs) ? [$preferredHost] : [];
-        $hostNames = array_unique(array_merge([$preferredHost], [$mainHostName], $failoverHostNames));
+        $hostNames = array_unique(array_merge($preferredHost, [$mainHostName], $failoverHostNames));
 
         $nonBlackListedHosts = [];
         foreach ($hostNames as $hostName) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -520,16 +520,14 @@ class Client implements LoggerAwareInterface
         $failoverHostNames = array_keys($this->failoverHostConfigs);
         shuffle($failoverHostNames);
         $mainHostName = array_rand($this->mainHostConfigs);
-        $hostNames = array_unique(array_merge($preferredHost ? [$preferredHost] : [], [$mainHostName], $failoverHostNames));
+        $preferredHost = in_array($preferredHost, $cachedHostConfigs) ? [$preferredHost] : [];
+        $hostNames = array_unique(array_merge([$preferredHost], [$mainHostName], $failoverHostNames));
 
         $nonBlackListedHosts = [];
         foreach ($hostNames as $hostName) {
             $blackListedUntil = $cachedHostConfigs[$hostName]['blacklistedUntil'] ?? null;
             if (!$blackListedUntil || $blackListedUntil < time()) {
-                // Make sure the host actually has a valid config before trying to add it to the list.
-                if (in_array($hostName, $cachedHostConfigs)) {
-                    $nonBlackListedHosts[$hostName] = $cachedHostConfigs[$hostName];
-                }
+                $nonBlackListedHosts[$hostName] = $cachedHostConfigs[$hostName];
             }
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -526,7 +526,10 @@ class Client implements LoggerAwareInterface
         foreach ($hostNames as $hostName) {
             $blackListedUntil = $cachedHostConfigs[$hostName]['blacklistedUntil'] ?? null;
             if (!$blackListedUntil || $blackListedUntil < time()) {
-                $nonBlackListedHosts[$hostName] = $cachedHostConfigs[$hostName];
+                // Make sure the host actually has a valid config before trying to add it to the list.
+                if (in_array($hostName, $cachedHostConfigs)) {
+                    $nonBlackListedHosts[$hostName] = $cachedHostConfigs[$hostName];
+                }
             }
         }
 


### PR DESCRIPTION
@mattabullock please review. This broke pinning hosts, aka setting the main/failover config to the same arrays, then having a preferred host come back that is not in those configs. We would then return a host with no port, which resulted in an error when the client tried to reconnect to the preferred host. 