### PR TITLE
build version 1.4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
This adds 1.4.6 at the head of master, because 1.4.5 was accidentally pointing at an older commit.