### PR TITLE
Prefix commitCount with _ to indicate internal property

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -282,7 +282,7 @@ try {
                         // keep the same commitCount because we need the finishJob call below to run in a server that has
                         // the commit of the GetJobs call above or the job we are trying to finish might be in QUEUED state.
                         $commitCount = Client::getInstance()->commitCount;
-                        Client::clearInstancesAfterFork($job['data']['commitCounts'] ?? []);
+                        Client::clearInstancesAfterFork($job['data']['_commitCounts'] ?? []);
                         $bedrock = Client::getInstance();
                         $bedrock->commitCount = $commitCount;
                         $jobs = new Jobs($bedrock);

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -161,7 +161,7 @@ class Jobs extends Plugin
             'CreateJob',
             [
                 'name' => $name,
-                'data' => array_merge($data ?? [], count($commitCounts) ? ['commitCounts' => $commitCounts] : []),
+                'data' => array_merge($data ?? [], count($commitCounts) ? ['_commitCounts' => $commitCounts] : []),
                 'firstRun' => $firstRun,
                 'repeat' => $repeat,
                 'unique' => $unique,
@@ -200,7 +200,7 @@ class Jobs extends Plugin
         }
         $commitCounts = Client::getCommitCounts();
         foreach ($jobs as $i => $job) {
-            $jobs[$i]['data'] = array_merge($jobs[$i]['data'] ?? [], count($commitCounts) ? ['commitCounts' => $commitCounts] : []);
+            $jobs[$i]['data'] = array_merge($jobs[$i]['data'] ?? [], count($commitCounts) ? ['_commitCounts' => $commitCounts] : []);
         }
 
         $response = $this->call(
@@ -265,7 +265,7 @@ class Jobs extends Plugin
             "UpdateJob",
             [
                 "jobID" => $jobID,
-                "data" => array_merge($data ?? [], count($commitCounts) ? ['commitCounts' => $commitCounts] : []),
+                "data" => array_merge($data ?? [], count($commitCounts) ? ['_commitCounts' => $commitCounts] : []),
                 "repeat" => $repeat,
                 "idempotent" => true,
             ]


### PR DESCRIPTION
@tylerkaraszewski after talking with @quinthar we decided to rename the `commitCount` data to `_commitCount` to indicate that it is an internal property used by bedrock. We are really breaking the encapsulation (`data` should belong to the consumer) with this change, but is better than the alternative (add a new column in the jobs table to save that information).

Merge this before creating your version for the timeout change, then your version will already include this (that's why I did not create a version in this PR)