### PR TITLE
Set default bedrock command timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.4.8",
+    "version": "1.4.9",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.4.9",
+    "version": "1.5.0",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -88,7 +88,7 @@ class Client implements LoggerAwareInterface
     private $readTimeout;
 
     /**
-     * @var int Timeout to pass to bedrock, in MS.
+     * @var int Timeout to pass to bedrock.
      */
     private $bedrockTimeout;
 
@@ -137,7 +137,7 @@ class Client implements LoggerAwareInterface
      *                      array|null           failovers           List of hosts to use as failovers
      *                      int|null             connectionTimeout   Timeout to use when connecting
      *                      int|null             readTimeout         Timeout to use when reading
-     *                      int|null             bedrockTimeout      Timeout to use for bedrock commands (in ms, not seconds)
+     *                      int|null             bedrockTimeout      Timeout to use for bedrock commands
      *                      LoggerInterface|null logger              Class to use for logging
      *                      StatsInterface|null  stats               Class to use for statistics tracking
      *                      string|null          writeConsistency    The bedrock write consistency we want to use
@@ -221,7 +221,7 @@ class Client implements LoggerAwareInterface
             'failoverHostConfigs' => ['localhost' => ['blacklistedUntil' => 0, 'port' => 8888]],
             'connectionTimeout' => 1,
             'readTimeout' => 300,
-            'bedrockTimeout' => 290000,
+            'bedrockTimeout' => 290,
             'logger' => new NullLogger(),
             'stats' => new NullStats(),
             'writeConsistency' => 'ASYNC',
@@ -313,7 +313,7 @@ class Client implements LoggerAwareInterface
         }
 
         if (!$headers['timeout'] && $this->bedrockTimeout) {
-            $headers['timeout'] = $this->bedrockTimeout;
+            $headers['timeout'] = $this->bedrockTimeout * 1000;
         }
 
         $this->logger->info('Bedrock\Client - Starting a request', [

--- a/src/Client.php
+++ b/src/Client.php
@@ -335,7 +335,7 @@ class Client implements LoggerAwareInterface
             $headers['priority'] = $this->commandPriority;
         }
 
-        if (!$headers['timeout'] && $this->bedrockTimeout) {
+        if (!array_key_exists('timeout', $headers) && $this->bedrockTimeout) {
             $headers['timeout'] = $this->bedrockTimeout * 1000;
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -88,6 +88,11 @@ class Client implements LoggerAwareInterface
     private $readTimeout;
 
     /**
+     * @var int Timeout to pass to bedrock, in MS.
+     */
+    private $bedrockTimeout;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -132,6 +137,7 @@ class Client implements LoggerAwareInterface
      *                      array|null           failovers           List of hosts to use as failovers
      *                      int|null             connectionTimeout   Timeout to use when connecting
      *                      int|null             readTimeout         Timeout to use when reading
+     *                      int|null             bedrockTimeout      Timeout to use for bedrock commands (in ms, not seconds)
      *                      LoggerInterface|null logger              Class to use for logging
      *                      StatsInterface|null  stats               Class to use for statistics tracking
      *                      string|null          writeConsistency    The bedrock write consistency we want to use
@@ -148,6 +154,7 @@ class Client implements LoggerAwareInterface
         $this->failoverHostConfigs = $config['failoverHostConfigs'];
         $this->connectionTimeout = $config['connectionTimeout'];
         $this->readTimeout = $config['readTimeout'];
+        $this->bedrockTimeout = $config['bedrockTimeout'];
         $this->logger = $config['logger'];
         $this->stats = $config['stats'];
         $this->writeConsistency = $config['writeConsistency'];
@@ -214,6 +221,7 @@ class Client implements LoggerAwareInterface
             'failoverHostConfigs' => ['localhost' => ['blacklistedUntil' => 0, 'port' => 8888]],
             'connectionTimeout' => 1,
             'readTimeout' => 300,
+            'bedrockTimeout' => 290000,
             'logger' => new NullLogger(),
             'stats' => new NullStats(),
             'writeConsistency' => 'ASYNC',
@@ -302,6 +310,10 @@ class Client implements LoggerAwareInterface
 
         if ($this->commandPriority) {
             $headers['priority'] = $this->commandPriority;
+        }
+
+        if (!$headers['timeout'] && $this->bedrockTimeout) {
+            $headers['timeout'] = $this->bedrockTimeout;
         }
 
         $this->logger->info('Bedrock\Client - Starting a request', [


### PR DESCRIPTION
@iwiznia 

Fixes: https://github.com/Expensify/Expensify/issues/90348

This sets the default timeout for a bedrock command to be just short of the socket timeout. This overrides the default 30 second timeout in bedrock.

Makes tag ~1.4.9 1.5.0~ 1.5.1 to use in web.
(I am bad at making tags after things are done)

I tested this by doing the following:

Edit `BedrockCore::peekCommand` to always throw `STHROW("555 Timeout")`. This means every command will timeout. I verified that the PHP Client throws a `ConnectionFailure` by loading the dev website and inspecting the logs.

For the normal case, using an unedited Bedrock, I loaded the dev website and watched the logs and saw:

```
2018-10-16T17:39:46.768988+00:00 expensidev php-cgi: NaLixC /index.php tyler@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetPersonalDetailsForEmails' clusterName: 'auth' headers: '[emailList: 'tyler@expensify.com' idempotent: '1' requestID: 'NaLixC' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
```

Showing the 290,000ms timeout default for the command.