### PR TITLE
Only retry timeout that isn't from a SQLite query

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -632,9 +632,10 @@ class Client implements LoggerAwareInterface
             $this->commitCount = (int) $responseHeaders["commitCount"];
         }
 
-        // We treat a timeout as a ConnectionFailure
-        if (intval($codeLine) === 555) {
-            throw new ConnectionFailure('Timeout waiting for bedrock response');
+        // We treat a non-sqlite-query timeout as a ConnectionFailure.
+        // We don't want to retry timed out queries as this will just overwhelm the servers.
+        if ($codeLine === '555 Timeout') {
+            throw new ConnectionFailure('Internal Bedrock command timeout (555 Timeout)');
         }
 
         return [


### PR DESCRIPTION
@tylerkaraszewski @iwiznia please review

https://github.com/Expensify/Expensify/issues/92336

We only want to retry time outs that weren't caused by long running queries. The latter will be thrown with a different message.

# Tests

Ensured that ConnectionFailure is caught for `555 Timeout`. Ensured that exception bubbles up for any other `555 Timeout peeking command`, etc. 