### PR TITLE
Check for current host in list of possible hosts

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -385,7 +385,7 @@ class Client implements LoggerAwareInterface
             reset($hostConfigs);
             $numRetriesLeft = count($hostConfigs) - 1;
 
-            if ($this->lastHost && $this->socket && array_key_exists($this->lastHost, $hostConfigs)) {
+            if ($this->lastHost && $this->socket && !isset($this->lastHost, $hostConfigs)) {
                 // If we have a socket connection, but the current host is no longer in the list of available host
                 // configs, close the socket so it can be reset.
                 @socket_close($this->socket);

--- a/src/Client.php
+++ b/src/Client.php
@@ -386,9 +386,10 @@ class Client implements LoggerAwareInterface
             $numRetriesLeft = count($hostConfigs) - 1;
 
             // If we already have a socket for this instance, then we first try to reuse it
-            if ($this->socket) {
+            if ($this->socket && array_key_exists($this->lastHost, $hostConfigs)) {
                 $hostName = $this->lastHost;
             } else {
+                $this->socket = null;
                 $hostName = key($hostConfigs);
                 $this->lastHost = $hostName;
             }

--- a/src/Client.php
+++ b/src/Client.php
@@ -385,16 +385,17 @@ class Client implements LoggerAwareInterface
             reset($hostConfigs);
             $numRetriesLeft = count($hostConfigs) - 1;
 
-            // If we already have a socket for this instance, then we first try to reuse it
-            if ($this->socket && array_key_exists($this->lastHost, $hostConfigs)) {
-                $hostName = $this->lastHost;
-            } else {
+            if ($this->lastHost && $this->socket && array_key_exists($this->lastHost, $hostConfigs)) {
                 // If we have a socket connection, but the current host is no longer in the list of available host
                 // configs, close the socket so it can be reset.
-                if ($this->socket) {
-                    @socket_close($this->socket);
-                    $this->socket = null;
-                }
+                @socket_close($this->socket);
+                $this->socket = null;
+                $this->logger->info('Bedrock\Client - Not reusing socket because the host it was connected to is no longer available', ['host' => $this->lastHost]);
+            }
+            // If we already have a socket for this instance, then we first try to reuse it
+            if ($this->socket) {
+                $hostName = $this->lastHost;
+            } else {
                 // Try the first possible host.
                 $hostName = key($hostConfigs);
                 $this->lastHost = $hostName;

--- a/src/Client.php
+++ b/src/Client.php
@@ -389,7 +389,13 @@ class Client implements LoggerAwareInterface
             if ($this->socket && array_key_exists($this->lastHost, $hostConfigs)) {
                 $hostName = $this->lastHost;
             } else {
-                $this->socket = null;
+                // If we have a socket connection, but the current host is no longer in the list of available host
+                // configs, close the socket so it can be reset.
+                if ($this->socket) {
+                    @socket_close($this->socket);
+                    $this->socket = null;
+                }
+                // Try the first possible host.
                 $hostName = key($hostConfigs);
                 $this->lastHost = $hostName;
             }

--- a/src/Client.php
+++ b/src/Client.php
@@ -385,7 +385,7 @@ class Client implements LoggerAwareInterface
             reset($hostConfigs);
             $numRetriesLeft = count($hostConfigs) - 1;
 
-            if ($this->lastHost && $this->socket && !isset($this->lastHost, $hostConfigs)) {
+            if ($this->lastHost && $this->socket && !isset($hostConfigs[$this->lastHost])) {
                 // If we have a socket connection, but the current host is no longer in the list of available host
                 // configs, close the socket so it can be reset.
                 @socket_close($this->socket);


### PR DESCRIPTION
@flodnv will you please review this?
cc: @iwiznia

This PR adds a check to see if the current host config on a socket is still on the list of possible hosts before trying to send a request to that host. This should prevent us from getting empty Bedrock responses.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/89518

# Tests
1. Created a request in Web-Expensify called `requestTest.php` that ran `ReportStore::getByID($_REQUEST['authToken], 144)`
1. Manually forced the host to be blacklisted after a successful request was made in Client.php
1. Logged into the website on dev
1. Loaded www.expensify.com.dev/requestTest.php
1. Tailed the logs and confirmed that the first request to the host was successful, that the host was then blacklisted, and that we hit log line indicating that it would not be reused because it was no longer available.

```
2018-11-12T23:29:41.255476+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] The host configs are: {"auth":{"port":4444},"127.0.0.1":{"port":4444}}
2018-11-12T23:29:41.255621+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] the lastHost is: ""
2018-11-12T23:29:41.255761+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] there is no socket.
2018-11-12T23:29:41.255972+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] We do not have a socket and will generate a new one.
2018-11-12T23:29:41.270298+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] Manually blacklisting the host without resetting the socket until: 1542065382
2018-11-12T23:29:41.314857+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] The host configs are: {"127.0.0.1":{"port":4444}}
2018-11-12T23:29:41.315153+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] the lastHost is: "auth"
2018-11-12T23:29:41.315336+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] there is a socket.
2018-11-12T23:29:41.315959+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] Bedrock\Client - Not reusing socket because the host it was connected to is no longer available ~~ host: 'auth'
2018-11-12T23:29:41.316171+00:00 expensidev php-cgi: kI1MJm /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] We do not have a socket and will generate a new one.
```

1. Removed the code that manually blacklisted the host, re-ran the `requestTest` file, and confirmed the first and second calls from the client used the same host and socket:

```
2018-11-12T23:34:27.600633+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] The host configs are: {"auth":{"port":4444,"blacklistedUntil":1542065382},"127.0.0.1":{"port":4444}}
2018-11-12T23:34:27.600758+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] the lastHost is: ""
2018-11-12T23:34:27.600878+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] there is no socket.
2018-11-12T23:34:27.600998+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] We do not have a socket and will generate a new one.
2018-11-12T23:34:27.609703+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] The host configs are: {"auth":{"port":4444,"blacklistedUntil":1542065382},"127.0.0.1":{"port":4444}}
2018-11-12T23:34:27.609837+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] the lastHost is: "auth"
2018-11-12T23:34:27.609957+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] there is a socket.
2018-11-12T23:34:27.610081+00:00 expensidev php-cgi: sy4vOv /requestTest.php jbexpensifytest+2@gmail.com !web! ?api? [info] [testRequest] We have a socket and are reusing it.
```

# QA
No