### PR TITLE
Make all cache commands idempotent

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -59,7 +59,7 @@ class Cache extends Plugin
         if ($version) {
             // Invalidate all other versions of this name before setting
             $headers["invalidateName"] = "$name/*";
-            $headers["name"]           = "$name/$version";
+            $headers["name"] = "$name/$version";
         } else {
             // Just set this name
             $headers["name"] = "$name/";

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -82,6 +82,8 @@ class Cache extends Plugin
 
             return;
         }
+        // Both writing to and reading from the cache are always idempotent operations
+        $headers['idempotent'] = true;
 
         try {
             return $this->client->getStats()->benchmark("bedrock.cache.$method", function () use ($method, $headers, $body) {


### PR DESCRIPTION
@fnwbr please review

Needed to fix https://github.com/Expensify/Expensify/issues/92647

Tests:
```
>>> $c = Expensify\Bedrock\Client::getInstance()
=> Expensify\Bedrock\Client {#2511
     +commitCount: null,
   }
>>> $h = new Expensify\Bedrock\Cache($c)
=> Expensify\Bedrock\Cache {#2518}
>>> $h->read('caca')
=> [
     "headers" => [
       "commitCount" => "3833",
       "nodeName" => "bedrock",
       "peekTime" => "5319",
       "totalTime" => "5428",
       "unaccountedTime" => "79",
       "Content-Length" => "0",
     ],
     "body" => [],
     "size" => 133,
     "codeLine" => "404 No match found",
     "code" => 404,
   ]
>>> $h->write('caca', 1)
=> [
     "headers" => [
       "Content-Length" => "0",
     ],
     "body" => [],
     "size" => 46,
     "codeLine" => "202 Successfully queued",
     "code" => 202,
   ]
```
Logs:
```
2018-11-14T11:46:31.100041+00:00 expensidev php: AIyIHx /home/vagrant/.config/composer/vendor/bin/psysh we@dont.know !script! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'ReadCache' clusterName: 'webrock' headers: '[name: 'caca/*' idempotent: '1' requestID: 'AIyIHx' lastIP: '73.95.137.73' writeConsistency: 'ASYNC' priority: '250' timeout: '290000']'
2018-11-14T11:46:51.790020+00:00 expensidev php: AIyIHx /home/vagrant/.config/composer/vendor/bin/psysh we@dont.know !script! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'WriteCache' clusterName: 'webrock' headers: '[Connection: 'forget' name: 'caca/' idempotent: '1' commitCount: '3833' requestID: 'AIyIHx' lastIP: '73.95.137.73' writeConsistency: 'ASYNC' priority: '250' timeout: '290000']'
```