### PR TITLE
Log PID of workers

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -40,10 +40,7 @@ $options = getopt('', ['maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 
 'intervalDurationSeconds::', 'doubleBackoffPreventionIntervalFraction::', 'multiplicativeDecreaseFraction::',
 'jobsToAddPerSecond::', ]);
 
-// Store parent ID to determine if we should continue forking
-$thisPID = getmypid();
-
-$workerPath = @$options['workerPath'];
+$workerPath = $options['workerPath'] ?? null;
 if (!$workerPath) {
     echo "Usage: sudo -u user php ./bin/BedrockWorkerManager.php --workerPath=<workerPath> [--jobName=<jobName> --maxLoad=<maxLoad> --maxIterations=<iteration> --writeConsistency=<consistency>  --enableLoadHandler --minSafeJobs=<minSafeJobs> --maxJobsInSingleRun=<maxJobsInSingleRun> --maxSafeTime=<maxSafeTime> --localJobsDBPath=<localJobsDBPath> --debugThrottle]\r\n";
     exit(1);

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -295,6 +295,7 @@ try {
                             'name' => $job['name'],
                             'id' => $job['jobID'],
                             'extraParams' => $extraParams,
+                            'pid' => getmypid(),
                         ]);
                         $stats->counter('bedrockJob.create.'.$job['name']);
 


### PR DESCRIPTION
@iwiznia please review

More than once have I thought "Maybe this process is stuck since days, let's see what it is doing".... but the PID is never logged. Damn, I now realize it gets logged [here](https://github.com/Expensify/Bedrock-PHP/blob/8dbcbd8d873ce21c6baeb7c10650482827db2613/bin/BedrockWorkerManager.php#L401), but logging it here will make it more visible IMO (that's where I was looking at to find it) 😬 

# Tests

Copied the code locally, watched logs
```
2018-11-19T14:25:18.467180+00:00 expensidev php: xZFwQx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Fork succeeded, child process, running job ~~ PID: '10235' name: 'www-prod/EmailNotification' id: '20' extraParams: ''
2018-11-19T14:25:18.481757+00:00 expensidev php: 0CGoty vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Fork succeeded, child process, running job ~~ PID: '10236' name: 'www-prod/EmailNotification' id: '24' extraParams: ''
```