### PR TITLE
Check for 1 and true in BedrockWorkerManager

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -308,7 +308,7 @@ try {
 
                             // Open the DB connection after the fork in the child process.
                             try {
-                                if ($worker->getParam("mockRequest") !== true) {
+                                if (!$worker->getParam("mockRequest")) {
                                     // Run the worker.  If it completes successfully, finish the job.
                                     $worker->run();
 

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -308,7 +308,7 @@ try {
 
                             // Open the DB connection after the fork in the child process.
                             try {
-                                if ($worker->getParam("mockRequest") !== '1' && $worker->getParam("mockRequest") !== 'true') {
+                                if ($worker->getParam("mockRequest") !== 'true') {
                                     // Run the worker.  If it completes successfully, finish the job.
                                     $worker->run();
 

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -308,7 +308,7 @@ try {
 
                             // Open the DB connection after the fork in the child process.
                             try {
-                                if ($worker->getParam("mockRequest") !== '1') {
+                                if ($worker->getParam("mockRequest") !== '1' && $worker->getParam("mockRequest") !== 'true') {
                                     // Run the worker.  If it completes successfully, finish the job.
                                     $worker->run();
 

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -308,7 +308,7 @@ try {
 
                             // Open the DB connection after the fork in the child process.
                             try {
-                                if ($worker->getParam("mockRequest") !== 'true') {
+                                if ($worker->getParam("mockRequest") !== true) {
                                     // Run the worker.  If it completes successfully, finish the job.
                                     $worker->run();
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Change the if condition to confirm if a bedrock job is mock job by checking if the `mockRequest` parameter is `true` instead of `1`. 

$ https://github.com/Expensify/Expensify/issues/85244

# Test
1. Uncomment this [line](https://github.com/Expensify/Web-Expensify/blob/dc63631bde51cd4517b6dec8b0137767cd191089/www-dev-config.php#L4) in Web-Expensify
2. Start the bedrock worker manager and tail the logs for the remainder of the steps
3. Trigger a job through `Web-Expensify` (I did a ReportExporter job through IS)
4. Monitor the logs to verify that we created the job with `'mockRequest': 1`
![image](https://user-images.githubusercontent.com/9564185/49318692-6de4d400-f4ae-11e8-9c15-706ccd1d8988.png)
5. After the job is completed, look for this log line to verify that we skipped [this section](https://github.com/Expensify/Bedrock-PHP/blob/master/bin/BedrockWorkerManager.php#L313) for the mocked job
![image](https://user-images.githubusercontent.com/9564185/49318798-d3d15b80-f4ae-11e8-84e9-23248fca56cf.png)


