### PR TITLE
Check $_server for mock request header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/Expensify/PHP-Libs.git"
+            "url": "https://github.com/Expensify/Bedrock-PHP.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.5.3",
+    "version": "1.5.5",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -173,7 +173,7 @@ class Client implements LoggerAwareInterface
             $this->mockRequests = $config['mockRequests'];
         } elseif (isset($_SERVER['HTTP_X_MOCK_REQUEST'])) {
             // otherwise check the http headers and set it
-            $this->mockRequests = (bool) $_SERVER['HTTP_X_MOCK_REQUEST'];
+            $this->mockRequests = isset($_SERVER['HTTP_X_MOCK_REQUEST']);
         }
 
         // Make sure we have at least one host configured

--- a/src/Client.php
+++ b/src/Client.php
@@ -173,7 +173,7 @@ class Client implements LoggerAwareInterface
             $this->mockRequests = $config['mockRequests'];
         } else {
             // otherwise check the http headers
-            $this->mockRequests = isset($_SERVER['HTTP_X-Mock-Request']);
+            $this->mockRequests = isset($_SERVER['HTTP_X_MOCK_REQUEST']);
         }
 
         // Make sure we have at least one host configured

--- a/src/Client.php
+++ b/src/Client.php
@@ -171,7 +171,7 @@ class Client implements LoggerAwareInterface
         // If the caller explicitly set `mockRequests`, use that value.
         if (isset($config['mockRequests'])) {
             $this->mockRequests = $config['mockRequests'];
-        } elseif (isset($_SERVER['HTTP_X_MOCK_REQUEST']))_ {
+        } elseif (isset($_SERVER['HTTP_X_MOCK_REQUEST'])) {
             // otherwise check the http headers and set it
             $this->mockRequests = $_SERVER['HTTP_X_MOCK_REQUEST'];
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -171,12 +171,9 @@ class Client implements LoggerAwareInterface
         // If the caller explicitly set `mockRequests`, use that value.
         if (isset($config['mockRequests'])) {
             $this->mockRequests = $config['mockRequests'];
-        } elseif (function_exists('getallheaders')) {
-            // otherwise pull from the request headers.
-            $requestHeaders = getallheaders();
-            if (isset($requestHeaders['X-Mock-Request'])) {
-                $this->mockRequests = true;
-            }
+        } else {
+            // otherwise check the http headers
+            $this->mockRequests = isset($_SERVER['HTTP_X-Mock-Request']);
         }
 
         // Make sure we have at least one host configured

--- a/src/Client.php
+++ b/src/Client.php
@@ -171,9 +171,9 @@ class Client implements LoggerAwareInterface
         // If the caller explicitly set `mockRequests`, use that value.
         if (isset($config['mockRequests'])) {
             $this->mockRequests = $config['mockRequests'];
-        } else {
-            // otherwise check the http headers
-            $this->mockRequests = isset($_SERVER['HTTP_X_MOCK_REQUEST']);
+        } elseif (isset($_SERVER['HTTP_X_MOCK_REQUEST']))_ {
+            // otherwise check the http headers and set it
+            $this->mockRequests = $_SERVER['HTTP_X_MOCK_REQUEST'];
         }
 
         // Make sure we have at least one host configured

--- a/src/Client.php
+++ b/src/Client.php
@@ -173,7 +173,7 @@ class Client implements LoggerAwareInterface
             $this->mockRequests = $config['mockRequests'];
         } elseif (isset($_SERVER['HTTP_X_MOCK_REQUEST'])) {
             // otherwise check the http headers and set it
-            $this->mockRequests = $_SERVER['HTTP_X_MOCK_REQUEST'];
+            $this->mockRequests = (bool) $_SERVER['HTTP_X_MOCK_REQUEST'];
         }
 
         // Make sure we have at least one host configured


### PR DESCRIPTION
When we moved over to FPM the version we are on doesn't include `getallheaders` so the call errors with an unknown function error.

Discovered apart of https://github.com/Expensify/Expensify/issues/95795 and discussion in #infra https://expensify.slack.com/archives/C094TGUTZ/p1546619668475300

I'm not 100% on changing this since we safe guard with `function_exists` and FPM PHP 7.3 does have `getallheaders`