### PR TITLE
Create versionWatchFile if it doesn't exist

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -107,8 +107,11 @@ if ($enableLoadHandler) {
     $localDB->write($query);
 }
 
-// If --versionWatch is enabled, begin watching a version file for changes
+// If --versionWatch is enabled, begin watching a version file for changes. If the file doesn't exist, create it.
 $versionWatchFile = @$options['versionWatchFile'];
+if ($versionWatchFile && !file_exists($versionWatchFile)) {
+    touch($versionWatchFile);
+}
 $versionWatchFileTimestamp = $versionWatchFile && file_exists($versionWatchFile) ? filemtime($versionWatchFile) : false;
 
 // Wrap everything in a general exception handler so we can handle error

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.5.5",
+    "version": "1.5.6",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
If you add the versionWatchFile flag but the file doesn't exist, create it.

Part of https://github.com/Expensify/Expensify/issues/95570

# Tests
1. Make sure version watch file doesn't exist
2. Run BWM with `--versionWatchFile=<file>` flag
3. Confirm that BWM runs