### PR TITLE
Support logparam config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.5.6",
+    "version": "1.6.0",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -135,6 +135,11 @@ class Client implements LoggerAwareInterface
     private $commandPriority;
 
     /**
+     * @var ?string Extra data to add to the bedrock logs
+     */
+    private $logParam;
+
+    /**
      * Creates a reusable Bedrock instance.
      * All params are optional and values set in `configure` would be used if are not passed here.
      *
@@ -150,6 +155,7 @@ class Client implements LoggerAwareInterface
      *                      string|null          writeConsistency    The bedrock write consistency we want to use
      *                      int|null             maxBlackListTimeout When a host fails, it will blacklist it and not try to reuse it for up to this amount of seconds.
      *                      int|null             commandPriority     The priority to send the commands with
+     *                      string|null          logParam            Extra data to add to the bedrock logs
      *
      * @throws BedrockError
      */
@@ -167,6 +173,7 @@ class Client implements LoggerAwareInterface
         $this->writeConsistency = $config['writeConsistency'];
         $this->maxBlackListTimeout = $config['maxBlackListTimeout'];
         $this->commandPriority = $config['commandPriority'];
+        $this->logParam = $config['logParam'];
 
         // If the caller explicitly set `mockRequests`, use that value.
         if (isset($config['mockRequests'])) {
@@ -239,6 +246,7 @@ class Client implements LoggerAwareInterface
             'writeConsistency' => 'ASYNC',
             'maxBlackListTimeout' => 1,
             'commandPriority' => null,
+            'logParam' => null,
         ], self::$defaultConfig, $config);
     }
 
@@ -334,6 +342,10 @@ class Client implements LoggerAwareInterface
 
         if (!array_key_exists('timeout', $headers) && $this->bedrockTimeout) {
             $headers['timeout'] = $this->bedrockTimeout * 1000;
+        }
+
+        if (!array_key_exists('logParam', $headers) && $this->logParam) {
+            $headers['logParam'] = $this->logParam;
         }
 
         $this->logger->info('Bedrock\Client - Starting a request', [


### PR DESCRIPTION
Tests:
Go to onsignin, check webrock logs contain email:
```
2019-01-16T16:33:59.047790+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'CreateJob' clusterName: 'webrock' headers: '[name: 'www-prod/ScrapeCards?accountID=1' data: '[accountID: '1' _commitCounts: '[auth: '14855']']' firstRun: '' repeat: '' unique: '1' jobPriority: '500' parentJobID: '' Connection: 'forget' idempotent: '1' retryAfter: '' requestID: 'ICOQ4a' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000' logParam: 'ionatan@expensify.com']'
2019-01-16T16:33:59.048281+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'localhost'
2019-01-16T16:33:59.048474+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost']'
2019-01-16T16:33:59.048662+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Opening new socket ~~ host: 'localhost' cluster: 'webrock' pid: '15902'
2019-01-16T16:33:59.048842+00:00 expensidev bedrock: xxxxxx (STCPServer.cpp:63) acceptSocket [main] [dbug] Accepting socket from '127.0.0.1:40524' on port '0.0.0.0:8888'
2019-01-16T16:33:59.049108+00:00 expensidev bedrock: xxxxxx (BedrockServer.cpp:1420) postPoll [main] [info] Poll returned 1 sockets to inspect and we accepted 1 new sockets. Total to inspect: 1 of 1.
2019-01-16T16:33:59.049290+00:00 expensidev bedrock: xxxxxx (BedrockServer.cpp:1420) postPoll [main] [info] Poll returned 1 sockets to inspect and we accepted 0 new sockets. Total to inspect: 1 of 1.
2019-01-16T16:33:59.049469+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockServer.cpp:1493) postPoll [main] [info] Firing and forgetting 'CreateJob'
2019-01-16T16:33:59.049734+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockServer.cpp:1546) postPoll [main] [info] Queued new 'CreateJob' command from local client, with 0 commands already queued.
2019-01-16T16:33:59.049970+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'localhost' command: 'CreateJob' jsonCode: '202 Successfully queued' duration: '0.002' net: '0.002' wait: '0' proc: '0' commitCount: ''
2019-01-16T16:33:59.050202+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( expensidev.web.bedrock.jobs.CreateJob:2|ms )
2019-01-16T16:33:59.050380+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [dbug] StatsD - _send( expensidev.web.bedrockJob.call.response.CreateJob202:1|c )
2019-01-16T16:33:59.050696+00:00 expensidev php-cgi: ICOQ4a /onsignin.php ionatan@expensify.com !web! ?api? [info] Job created ~~ name: 'www-prod/ScrapeCards?accountID=1' id: ''
2019-01-16T16:33:59.051141+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockServer.cpp:762) worker [worker3] [info] Dequeued command CreateJob in worker, 0 commands in  queue.
2019-01-16T16:33:59.051335+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockServer.cpp:914) worker [worker3] [info] Forcing QUORUM for command 'CreateJob'.
2019-01-16T16:33:59.051572+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockCore.cpp:65) peekCommand [worker3] [dbug] Peeking at 'CreateJob' with priority: 500
2019-01-16T16:33:59.051785+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (SQLite.cpp:417) beginConcurrentTransaction [worker3] [dbug] [concurrent] Beginning transaction
2019-01-16T16:33:59.051966+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (libstuff.cpp:2368) SQuery [worker3] [dbug] BEGIN CONCURRENT
2019-01-16T16:33:59.052260+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (libstuff.cpp:2368) SQuery [worker3] [dbug] PRAGMA query_only = true;
2019-01-16T16:33:59.052452+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (libstuff.cpp:1296) _SParseJSONObject [worker3] [dbug] Parsed: 'accountID':'1'
2019-01-16T16:33:59.052711+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (libstuff.cpp:1296) _SParseJSONObject [worker3] [dbug] Parsed: '_commitCounts':'{"auth":14855}'
2019-01-16T16:33:59.053092+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (Jobs.cpp:274) peekCommand [worker3] [info] {Jobs} Unique flag was passed, checking existing job with name www-prod/ScrapeCards?accountID=1, mocked? false
2019-01-16T16:33:59.053312+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (libstuff.cpp:2368) SQuery [worker3] [dbug] SELECT jobID, data FROM jobs WHERE name='www-prod/ScrapeCards?accountID=1'  AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;
2019-01-16T16:33:59.063291+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (Jobs.cpp:288) peekCommand [worker3] [info] {Jobs} Job already existed and unique flag was passed, reusing existing job 5210490515700764152, mocked? false
2019-01-16T16:33:59.063555+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockCore.cpp:92) peekCommand [worker3] [info] Plugin 'Jobs' peeked command 'CreateJob'
2019-01-16T16:33:59.063733+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (libstuff.cpp:2368) SQuery [worker3] [dbug] PRAGMA query_only = false;
2019-01-16T16:33:59.063899+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockCore.cpp:126) peekCommand [worker3] [info] Responding '200 OK' to read-only 'CreateJob'.
2019-01-16T16:33:59.064073+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (libstuff.cpp:2368) SQuery [worker3] [dbug] ROLLBACK
2019-01-16T16:33:59.065698+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (SQLite.cpp:798) rollback [worker3] [info] Transaction rollback with 3 queries attempted, 0 served from cache for 'CreateJob'.
2019-01-16T16:33:59.065933+00:00 expensidev bedrock: ICOQ4a ionatan@expensify.com (BedrockCommand.cpp:286) finalizeTimingInfo [worker3] [info] command 'CreateJob' timing info (ms): 15 (1), 0 (0), 0, 0, 1, 0, 16, 0, 0. Upstream: 0, 0, 0, 0.
```