### PR TITLE
[HOLD] Fix timing log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -463,8 +463,8 @@ class Client implements LoggerAwareInterface
         }
 
         // Log how long this particular call took
-        $processingTime = (isset($response['headers']['processTime']) ? $response['headers']['processTime'] : 0) / 1000;
-        $serverTime = (isset($response['headers']['totalTime']) ? $response['headers']['totalTime'] : 0) / 1000;
+        $processingTime = ($response['headers']['processTime'] ?? 0) / 1000;
+        $serverTime = ($response['headers']['totalTime'] ?? 0) / 1000;
         $clientTime = round(microtime(true) - $timeStart, 3) * 1000;
         $networkTime = $clientTime - $serverTime;
         $waitTime = $serverTime - $processingTime;

--- a/src/Client.php
+++ b/src/Client.php
@@ -463,9 +463,9 @@ class Client implements LoggerAwareInterface
         }
 
         // Log how long this particular call took
-        $processingTime = isset($response['headers']['processTime']) ? $response['headers']['processTime'] : 0;
-        $serverTime = isset($response['headers']['totalTime']) ? $response['headers']['totalTime'] : 0;
-        $clientTime = round(microtime(true) - $timeStart, 3);
+        $processingTime = (isset($response['headers']['processTime']) ? $response['headers']['processTime'] : 0) / 1000;
+        $serverTime = (isset($response['headers']['totalTime']) ? $response['headers']['totalTime'] : 0) / 1000;
+        $clientTime = round(microtime(true) - $timeStart, 3) * 1000;
         $networkTime = $clientTime - $serverTime;
         $waitTime = $serverTime - $processingTime;
         $this->logger->info('Bedrock\Client - Request finished', [

--- a/src/Client.php
+++ b/src/Client.php
@@ -390,7 +390,7 @@ class Client implements LoggerAwareInterface
         // If we passed a preferred host and we already had a connected socket, but to a different host and the preferred
         // host is not blacklisted (the preferred host is returned first in the possible hosts array only when it's not blacklisted)
         // then we close the socket in order to connect to the preferred one.
-        $closeSocketAfterRequest = array_key_exists('Connection', $headers) ? $headers['Connection'] : $this->stickySocket;
+        $closeSocketAfterRequest = array_key_exists('Connection', $headers) ? $headers['Connection'] : !$this->stickySocket;
         if ($preferredHost && $this->socket && key($hostConfigs) !== $this->lastHost) {
             @socket_close($this->socket);
             $this->socket = null;


### PR DESCRIPTION
@coleaeason please review

Holding on https://github.com/Expensify/Bedrock-PHP/pull/120 or I will get conflicts.

Related to https://github.com/Expensify/Expensify/issues/70743#issuecomment-457195152

Tests:
```
2019-01-24T13:27:34.834042+00:00 expensidev bedrock: xGChxM (BedrockCommand.cpp:286) finalizeTimingInfo [worker3] [info] command 'SetNameValuePair' timing info (ms): 5 (1), 0 (0), 0, 0, 0, 0, 5, 0, 0. Upstream: 0, 0, 0, 0.
2019-01-24T13:27:36.983074+00:00 expensidev php-cgi: xGChxM /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'SetNameValuePair' jsonCode: '200 OK' duration: '11' net: '5.619' wait: '5.381' proc: '0' commitCount: '14927'
```