### PR TITLE
Remove logParam from getInstance method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.6.2",
+    "version": "1.6.4",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -201,6 +201,7 @@ class Client implements LoggerAwareInterface
         $configForHash = $config;
         unset($configForHash['logger']);
         unset($configForHash['stats']);
+        unset($configForHash['logParam']);
         $hash = sha1(print_r($configForHash, true));
         if (isset(self::$instances[$hash])) {
             return self::$instances[$hash];


### PR DESCRIPTION
Fixes Expensify/Expensify#96880

Check that commitCount is correctly preserved for webrock in BWM.

The getInstance method uses the config passed and the default config to build a new instance of the Client or to return an existing one that has been built before that has the same configuration. When we added the `logParam` config, it broke this system in BWM, because we first configure it with logParam `null` and then we re-configure it with logParam as the email of the user that owns the job being run, that made it so it returned a new instance of the Client for each job, one that did not have the commitCount set correctly.