### PR TITLE
Fix timing log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -457,9 +457,9 @@ class Client implements LoggerAwareInterface
         }
 
         // Log how long this particular call took
-        $processingTime = isset($response['headers']['processTime']) ? $response['headers']['processTime'] : 0;
-        $serverTime = isset($response['headers']['totalTime']) ? $response['headers']['totalTime'] : 0;
-        $clientTime = round(microtime(true) - $timeStart, 3);
+        $processingTime = (isset($response['headers']['processTime']) ? $response['headers']['processTime'] : 0) / 1000;
+        $serverTime = (isset($response['headers']['totalTime']) ? $response['headers']['totalTime'] : 0) / 1000;
+        $clientTime = round(microtime(true) - $timeStart, 3) * 1000;
         $networkTime = $clientTime - $serverTime;
         $waitTime = $serverTime - $processingTime;
         $this->logger->info('Bedrock\Client - Request finished', [


### PR DESCRIPTION
@coleaeason please review

Related to Expensify/Expensify#70743 (comment)

Tests:
```
2019-01-24T13:27:34.834042+00:00 expensidev bedrock: xGChxM (BedrockCommand.cpp:286) finalizeTimingInfo [worker3] [info] command 'SetNameValuePair' timing info (ms): 5 (1), 0 (0), 0, 0, 0, 0, 5, 0, 0. Upstream: 0, 0, 0, 0.
2019-01-24T13:27:36.983074+00:00 expensidev php-cgi: xGChxM /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'SetNameValuePair' jsonCode: '200 OK' duration: '11' net: '5.619' wait: '5.381' proc: '0' commitCount: '14927'
```