### PR TITLE
Respect connection close coming from the server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.6.6",
+    "version": "1.6.7",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
Fixes issues like what we see in [this request](https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%2202Mdtd%22)+AND+timestamp:%5B2019-01-23T14:41:11.607Z+TO+2019-01-23T16:41:11.607Z%5D&index=logs_expensify-001259)

Tests:
- Make a bedrock request during server shutdown
- Check Connection:close is returned by the server
- Check client disconnects from the server and establishes a new connection
