### PR TITLE
Silence built-in warning, we'll handle it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.6.8",
+    "version": "1.6.9",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -515,7 +515,7 @@ class Client implements LoggerAwareInterface
         socket_clear_error($this->socket);
 
         // Send the information to the socket
-        $bytesSent = socket_send($this->socket, $rawRequest, strlen($rawRequest), MSG_EOF);
+        $bytesSent = @socket_send($this->socket, $rawRequest, strlen($rawRequest), MSG_EOF);
 
         // Failed to send anything
         if ($bytesSent === false) {


### PR DESCRIPTION
@iwiznia 

Fixes: https://github.com/Expensify/Expensify/issues/96913

All this does is silence the warning here. We already handle the error case here with our retry logic exactly how we're supposed to, but we don't keep the warning from logging. Sometimes after `connect` returns `115`, we get this error. The retry should handle it correctly.

I'll update the version number if you agree with this change.