### PR TITLE
Catch BWM crashing when jobID doesn't exist

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -352,7 +352,7 @@ try {
                                 ]);
                                 try {
                                     $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
-                                } catch (IllegalAction $e) {
+                                } catch (IllegalAction|DoesNotExist $e) {
                                     // IllegalAction is returned when we try to finish a job that's not RUNNING, this
                                     // can happen if we retried the command in a different server
                                     // after the first server actually ran the command (but we lost the response).

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -352,7 +352,7 @@ try {
                                 ]);
                                 try {
                                     $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());
-                                } catch (IllegalAction|DoesNotExist $e) {
+                                } catch (IllegalAction | DoesNotExist $e) {
                                     // IllegalAction is returned when we try to finish a job that's not RUNNING, this
                                     // can happen if we retried the command in a different server
                                     // after the first server actually ran the command (but we lost the response).

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.6.9",
+    "version": "1.7.0",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
We already attempt to catch if the job was retried elsewhere, so that would mean the jobID doesn't exist. The error name must've changed or something...

Part of https://github.com/Expensify/Expensify/issues/95570