### PR TITLE
Use proxy IP if it exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -325,7 +325,7 @@ class Client implements LoggerAwareInterface
         if (isset($GLOBALS['REQUEST_ID'])) {
             $headers['requestID'] = $GLOBALS['REQUEST_ID'];
         }
-        $headers['lastIP'] = $_SERVER['REMOTE_ADDR'] ?? null;
+        $headers['lastIP'] = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? null;
 
         // Set the write consistency
         if ($this->writeConsistency) {


### PR DESCRIPTION
@mattabullock Since we switched back to cloudflare we've been passing the wrong IP through to Bedrock for requests. This corrects that. 

## Tests:
Without a `X-Forwaded-For` header set:
```
2019-03-07T21:54:47.513599+00:00 expensidev php-fpm: kk53YW /api.php cole@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetPartnerList' clusterName: 'auth' headers: '[email: 'cole@expensify.com' idempotent: '1' logParam: 'cole@expensify.com' requestID: 'kk53YW' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
```
With `X-Forwarded-For` header set to `10.2.2.30`:
```
2019-03-07T21:54:43.529499+00:00 expensidev php-fpm: WRBteQ /api.php cole@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetPartnerList' clusterName: 'auth' headers: '[email: 'cole@expensify.com' idempotent: '1' logParam: 'cole@expensify.com' requestID: 'WRBteQ' lastIP: '10.2.2.30' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
```