### PR TITLE
Retry in all hosts again if all hosts failed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.7.2",
+    "version": "1.7.4",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -437,7 +437,7 @@ class Client implements LoggerAwareInterface
                     if ($numRetriesLeft) {
                         $this->logger->info('Bedrock\Client - Failed to send the whole request or to receive it; retrying because command is idempotent', ['host' => $hostName, 'message' => $e->getMessage(), 'retriesLeft' => $numRetriesLeft, 'exception' => $e]);
                     } else {
-                        $this->logger->error('Bedrock\Client - Failed to send the whole request or to receive it; not retrying', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
+                        $this->logger->error('Bedrock\Client - Failed to send the whole request or to receive it; not retrying because we are out of retries', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
                         $exception = $e;
                     }
                 } else {
@@ -459,13 +459,12 @@ class Client implements LoggerAwareInterface
             // before are now in the old version and not serving requests. So to cover this, we retry in all servers
             // once hoping it will find a server that works.
             if ($exception) {
-                if (!$retriedAllHosts) {
-                    $retriedAllHosts = true;
-                    $this->logger->info('All non blacklisted hosts failed, as a last resort try again in all hosts');
-                    $hostConfigs = $this->getPossibleHosts($preferredHost, true);
-                } else {
+                if ($retriedAllHosts) {
                     throw $exception;
                 }
+                $retriedAllHosts = true;
+                $this->logger->info('All non blacklisted hosts failed, as a last resort try again in all hosts');
+                $hostConfigs = $this->getPossibleHosts($preferredHost, true);
             }
         }
 


### PR DESCRIPTION
Attempts to fix the issue https://github.com/Expensify/Expensify/issues/69763

Holding to address any comments and create the new version.

Tests:
- Stop the auth server and make a request. Check it tries all possible hosts twice, the fails.
- Stop the auth server and make a request. Check it tries all possible hosts once, then start the server back up and check it finishes the request correctly.
- Modify code so that instead of ConnectionError it throws BedrockError, stop the auth server and make an idempotent request, check it tries to use all the hosts twice then fails.
- Modify code so that instead of ConnectionError it throws BedrockError, stop the auth server and make an idempotent request, check it tries to use all the hosts once, then start the server back and check it finishes the request correctly.
- Modify code so that instead of ConnectionError it throws BedrockError, stop the auth server and make a non idempotent request, check it throws immediately after fail.