### PR TITLE
Adding a function to call our bedrock endpoint of RequeueJobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.7.6",
+    "version": "1.7.7",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -370,6 +370,21 @@ class Jobs extends Plugin
     }
 
     /**
+     * Requeues a job back to QUEUED state. Updates the job name if provided as well.
+     */
+    public function requeueJobs(array $jobIDs, string $name = ''): array
+    {
+        return $this->call(
+            "RequeueJobs",
+            [
+                "jobIDs" => implode(',',$jobIDs),
+                "name" => $name,
+                "idempotent" => true,
+            ]
+        );
+    }
+
+    /**
      * Query a job's info.
      * Bedrock will return:
      *     - 200 - OK

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -377,7 +377,7 @@ class Jobs extends Plugin
         return $this->call(
             "RequeueJobs",
             [
-                "jobIDs" => implode(',',$jobIDs),
+                "jobIDs" => implode(',', $jobIDs),
                 "name" => $name,
                 "idempotent" => true,
             ]


### PR DESCRIPTION
@pecanoro, can you review this. 

We have a RequeueJobs method in Bedrock. This is just an intermediate function so that web-E can make use of that bedrock endpoint.

~On HOLD till this Bedrock [PR](https://github.com/Expensify/Bedrock/pull/643) gets merged.~

Helps with this [PR](https://github.com/Expensify/Web-Expensify/pull/24807) 

# Tests / QA
None