### PR TITLE
Allow unparsed Bedrock responses to PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.7.8",
+    "version": "1.7.9",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.7.9",
+    "version": "1.8.0",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -640,7 +640,7 @@ class Client implements LoggerAwareInterface
      * Receives and parses the response.
      *
      * @param bool $parseResponseBody flag indicating if the body should be parsed or passed unmodified.
-
+     *
      * @return array Response object including 'code', 'codeLine', 'headers', `size` and 'body'
      *
      * @throws BedrockError

--- a/src/Client.php
+++ b/src/Client.php
@@ -645,7 +645,7 @@ class Client implements LoggerAwareInterface
      *
      * @throws BedrockError
      */
-    private function receiveResponse(bool $parseResponseBody = true)
+    private function receiveResponse(bool $parseResponseBody)
     {
         // Make sure bedrock is returning something https://github.com/Expensify/Expensify/issues/11010
         if (@socket_recv($this->socket, $buf, self::PACKET_LENGTH, MSG_PEEK) === false) {


### PR DESCRIPTION
This change allows for  Bedrock to return non-JSON data to PHP without PHP failing to parse it as JSON. This is being used for this: https://github.com/Expensify/Expensify/issues/103358 to pass a gzipped blob of scoring data back from Bedrock to PHP