### PR TITLE
Do not call failJob when finishJob fails on retryAfter jobs

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -352,14 +352,18 @@ try {
                                     'extraParams' => $extraParams,
                                     'exception' => $e,
                                 ]);
-                                // Worker had a fatal error -- mark as failed.
-                                try {
-                                    $jobs->failJob($job['jobID']);
-                                } catch (IllegalAction | DoesNotExist $e) {
-                                    // IllegalAction is returned when we try to finish a job that's not RUNNING, this
-                                    // can happen if we retried the command in a different server
-                                    // after the first server actually ran the command (but we lost the response).
-                                    $logger->info('Failed to FailJob we probably retried a repeat command so it is safe to ignore', ['job' => $job, 'exception' => $e]);
+                                if ($job['retryAfter']) {
+                                    $logger->info('Could not call finishJob successfully, but job has retryAfter, so not failing the job and letting it be processed again');
+                                } else {
+                                    // Worker had a fatal error -- mark as failed.
+                                    try {
+                                        $jobs->failJob($job['jobID']);
+                                    } catch (IllegalAction | DoesNotExist $e) {
+                                        // IllegalAction is returned when we try to finish a job that's not RUNNING, this
+                                        // can happen if we retried the command in a different server
+                                        // after the first server actually ran the command (but we lost the response).
+                                        $logger->info('Failed to FailJob we probably retried a repeat command so it is safe to ignore', ['job' => $job, 'exception' => $e]);
+                                    }
                                 }
                             } finally {
                                 if ($enableLoadHandler) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
@pecanoro please review

Did what I proposed [here](https://github.com/Expensify/Expensify/issues/100552#issuecomment-500845895).

# Tests
Queue 2 jobs one with retry after and one without it
Modify bwm in order to fail the  finishJob call
Run bwm, check one of the jobs is in FAILED state and the other one in RUNQUEUED.