### PR TITLE
Add Admin Down Status Detection

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -553,10 +553,12 @@ function checkVersionFile(string $versionWatchFile, int $versionWatchFileTimesta
 /**
  * Watch for an ADMIN_DOWN file that can be touched. If in place, we
  * will not spawn new child processes until it has been removed.
+ *
+ * @param Expensify\Bedrock\Stats\StatsInterface $stats
  */
-function adminDownStatusEnabled(Expensify\Libs\StatsD $stats): bool
+function adminDownStatusEnabled($stats): bool
 {
-    return $stats->benchmark('bedrockWorkerManager.adminDownStatusEnabled', function() {
+    return $stats->benchmark('bedrockWorkerManager.adminDownStatusEnabled', function () {
         if (file_exists('/var/tmp/ADMIN_DOWN')) {
             return true;
         }

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -190,7 +190,7 @@ try {
                 break 2;
             }
 
-            if (adminDownStatusEnabled($stats) === true) {
+            if (adminDownStatusEnabled($stats)) {
                 $logger->info('ADMIN_DOWN status detected. Not spawning more child processes. Trying again after 1s.');
                 sleep(1);
 
@@ -559,10 +559,7 @@ function checkVersionFile(string $versionWatchFile, int $versionWatchFileTimesta
 function adminDownStatusEnabled($stats): bool
 {
     return $stats->benchmark('bedrockWorkerManager.adminDownStatusEnabled', function () {
-        if (file_exists('/var/tmp/ADMIN_DOWN')) {
-            return true;
-        }
-
-        return false;
+        clearstatcache(true, Jobs::ADMIN_DOWN_FILE_LOCATION);
+        return file_exists(Jobs::ADMIN_DOWN_FILE_LOCATION);
     });
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -80,6 +80,12 @@ class Jobs extends Plugin
     const PRIORITY_LOW = 0;
 
     /**
+     * Constant for the location of the file to look for to disable processing
+     * new jobs.
+     */
+    const ADMIN_DOWN_FILE_LOCATION = '/var/tmp/ADMIN_DOWN';
+
+    /**
      * Calls the Jobs plugin.
      *
      * @param string $method  Method to call


### PR DESCRIPTION
@iwiznia will you review this?

## Fixes
https://github.com/Expensify/Expensify/issues/95087

## Tests
1. Started up BWM
1. Ensured that jobs were processing and running
1. Tailed the logs
1. `touch /var/tmp/ADMIN_DOWN`
1. Ensure jobs stop processing
1. Look for status in the logs:
    ```
    2019-09-12T21:01:51.047036+00:00 expensidev php: SA0pNL vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] ADMIN_DOWN status detected. Not spawning more child processes. Trying again after 1s.
    ```
1. `rm /var/tmp/ADMIN_DOWN`
1. Ensure jobs start processing again
