### PR TITLE
adding patch level to php version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-    - '7.2'
+    - '7.2.22'
 
 install:
   - pecl install ast-0.1.7


### PR DESCRIPTION
@coleaeason  will you please review this?

Setting the PHP "patch release" version number, to line up with apt-mirror, and see if travis can work with it.

### Fixed Issues
related to https://github.com/Expensify/Expensify/issues/106963

# Tests
Travis