### PR TITLE
Update Jobs to accept new `priority` parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - pecl install ast-1.0.3
   - composer self-update
   - composer install --prefer-dist --no-interaction --dev
+  - phpenv config-rm xdebug.ini
 
 script:
     - ./ci/style.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
   - pecl install ast-1.0.3
   - composer self-update
   - composer install --prefer-dist --no-interaction --dev
-  - phpenv config-rm xdebug.ini
 
 script:
     - ./ci/style.php

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.8.3",
+    "version": "1.8.5",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.8.5",
+    "version": "1.8.4",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -271,7 +271,7 @@ class Jobs extends Plugin
      *
      * @return array
      */
-    public function updateJob($jobID, $data, $repeat = null, $priority = null)
+    public function updateJob($jobID, $data, $repeat = null, ?int $priority = null)
     {
         $commitCounts = Client::getCommitCounts();
         return $this->call(

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -266,7 +266,7 @@ class Jobs extends Plugin
      *
      * @param int    $jobID
      * @param array  $data
-     * @param string $repeat (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param string $repeat   (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
      * @param int    $priority (optional) The new priority of the job
      *
      * @return array

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -264,10 +264,10 @@ class Jobs extends Plugin
     /**
      * Updates the data associated with a job.
      *
-     * @param int    $jobID
-     * @param array  $data
-     * @param string $repeat   (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
-     * @param int    $priority (optional) The new priority of the job
+     * @param int      $jobID
+     * @param array    $data
+     * @param string   $repeat   (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param int|null $priority (optional) The new priority of the job
      *
      * @return array
      */

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -267,10 +267,11 @@ class Jobs extends Plugin
      * @param int    $jobID
      * @param array  $data
      * @param string $repeat (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param int    $priority (optional) The new priority of the job
      *
      * @return array
      */
-    public function updateJob($jobID, $data, $repeat = null)
+    public function updateJob($jobID, $data, $repeat = null, $priority = null)
     {
         $commitCounts = Client::getCommitCounts();
         return $this->call(
@@ -279,6 +280,7 @@ class Jobs extends Plugin
                 "jobID" => $jobID,
                 "data" => array_merge($data ?? [], count($commitCounts) ? ['_commitCounts' => $commitCounts] : []),
                 "repeat" => $repeat,
+                "jobPriority" => $priority,
                 "idempotent" => true,
             ]
         );


### PR DESCRIPTION
Adds in the `priority` parameter to match with the `jobPriority` parameter from `UpdateJobs`.

Bumping version to 1.8.4 

Corresponding Bedrock PR: https://github.com/Expensify/Bedrock/pull/691

Helps with https://github.com/Expensify/Expensify/issues/123018