### PR TITLE
Bump version to 1.8.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.8.6",
+    "version": "1.8.7",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
We did not bump the version [here](https://github.com/Expensify/Bedrock-PHP/pull/147), so doing it in this PR