### PR TITLE
Run travis on xenial and focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+jobs:
+  include:
+   - dist: xenial
+   - dist: focal
+
 language: php
 php:
   - '7.4.7'


### PR DESCRIPTION
Run travis tests on both xenial and focal in preparation for upcoming Ubuntu 20.04 upgrade.

## Fixed Issues

Part of Expensify/Expensify#137410