### PR TITLE
Revert "run travis on xenial and focal"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-jobs:
-  include:
-   - dist: xenial
-   - dist: focal
-
 language: php
 php:
   - '7.4.7'


### PR DESCRIPTION
This reverts commit 81adbb2243d24ed14d094dca382e62a67b659685.

As per [this comment](https://github.com/Expensify/Expensify/issues/137410#issuecomment-724841982), we've decided this isn't a valuable change for PHP repos.