### PR TITLE
Fix running job names containing a '/' after the '?'

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -243,12 +243,10 @@ try {
                     });
                     $localJobID = $localDB->getLastInsertedRowID();
                 }
-                $parts = explode('/', $job['name']);
                 $jobParts = explode('?', $job['name']);
                 $extraParams = count($jobParts) > 1 ? $jobParts[1] : null;
                 $job['name'] = $jobParts[0];
-                $workerName = $parts[count($parts) - 1];
-                $workerName = explode('?', $workerName)[0];
+                $workerName = explode('/', $job['name'])[1];
                 $workerFilename = $workerPath."/$workerName.php";
                 $logger->info("Looking for worker '$workerFilename'");
                 if (file_exists($workerFilename)) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.8.9",
+    "version": "1.9.0",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
For https://github.com/Expensify/Expensify/issues/103058

Jobs named like `www-prod/Worker?email=something/@domain.com` don't run because we log `No worker found, ignoring ~~ jobName: 'www-prod/Worker'`. This fixes that

### Tests

1. Reproduced locally by creating such a job with this name
2. Test again with the fix and see the job worker run
3. Ensure other job workers aren't affected by seeing them run as well 