### PR TITLE
Log RetryableException message

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -349,7 +349,7 @@ try {
                                     'name' => $job['name'],
                                     'id' => $job['jobID'],
                                     'extraParams' => $extraParams,
-                                    'message' => $e->getMessage(),
+                                    'exception' => $e,
                                 ]);
                                 try {
                                     $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -349,6 +349,7 @@ try {
                                     'name' => $job['name'],
                                     'id' => $job['jobID'],
                                     'extraParams' => $extraParams,
+                                    'message' => $e->getMessage(),
                                 ]);
                                 try {
                                     $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun());


### PR DESCRIPTION
## Details

TL;DR: Logs the entire `RetryableException` when caught in `BedrockWorkerManager.php`.

This is useful so we can have more details about the `RetryableException` was thrown.

## Tests

1. Create a bedrock job locally
    1. In the bedrock job's `run` method, throw a `RetryableException` - pass some string into the first parameter of the exception
    2. Example: see how it's being thrown in https://github.com/Expensify/Web-Expensify/pull/30574
2. Run the job, make sure the `RetryableException` gets thrown
3. See the exception data in the logs (search for `"Job could not complete, retrying"`, the exception's data should be shown nearby)

## Fixes
$ https://github.com/Expensify/Expensify/issues/159221

## Notes

Discussion here: https://expensify.slack.com/archives/C03TQ48KC/p1617365746278500