### PR TITLE
Make sure to strip query string parameters

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -245,6 +245,8 @@ try {
             $workers = [];
             $workerCount = 0;
             foreach ($jobsToRun as $job) {
+                $jobParts = explode('?', $job['name']);
+                $job['name'] = $jobParts[0];
                 $workerName = explode('/', $job['name'])[1];
                 if (isset($workers[$workerName])) {
                     $workers[$workerName]++;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.9.4",
+    "version": "1.9.5",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
We want to compare job names without query strings, or they all look different.

https://github.com/Expensify/Expensify/issues/177470