### PR TITLE
Fix warnings caused by previous change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.9.7",
+    "version": "1.9.8",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
This is a fix for the warnings seen here: https://expensify.slack.com/archives/C07J32337/p1632414804283600

As well as some other potential warnings.

Tested locally and verified it doesn't warn.