### PR TITLE
'jobName' is already a variable

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -250,8 +250,7 @@ try {
             if ($running) {
                 foreach ($running as $job) {
                     $jobParts = explode('?', $job ?? '');
-                    $jobName = $jobParts[0];
-                    $runningName = explode('/', $jobName)[1];
+                    $runningName = explode('/', $jobParts[0])[1];
                     if (isset($runningCounts[$runningName])) {
                         $runningCounts[$runningName]++;
                     } else {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.9.8",
+    "version": "1.9.9",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
`$jobName` is already declared so we're overwriting it with the code that's removed here.

This is causing *only* the first run of jobs to work when starting BWM, then the name is getting re-assigned, and it fails to find any more jobs until it's restarted and thus resets the job name.

issue:
$ https://github.com/Expensify/Expensify/issues/179264