### PR TITLE
More BWM Logging

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -258,7 +258,7 @@ try {
                     }
                     $runningTotal++;
                 }
-                $logger->info('[AIMD] currently running jobs');
+                $logger->info('[AIMD] current jobs (running):', $runningCounts);
             }
 
             // Now make a modified version of what's running that includes the jobs we just selected.
@@ -275,6 +275,7 @@ try {
                 }
                 $targetTotal++;
             }
+            $logger->info('[AIMD] current jobs (target):', $targetCounts);
 
             // Now we want to detect if the new target profile is "significantly different" to the existing profile.
             // How?
@@ -299,12 +300,17 @@ try {
             // to 15 to 20% of total jobs over several iterations, it may at no point hit a (for example) 10% increase
             // threshold, but a gradual increase like this should be handled by existing mechanisms. We are only trying
             // to detect sudden changes in job profiles with this code.
+            $jobIncreases = [];
             foreach ($targetCounts as $name => $count) {
                 $targetPercent = $count / max($targetTotal, 1);
                 $runningPercent = ($runningCounts[$name] ?? 0) / max($runningTotal, 1);
                 if ($runningPercent + $profileChangeThreshold < $targetPercent) {
-                    $logger->info('[AIMD] Job profile changed, '.$name.' increased from '.$runningPercent.' to '.$targetPercent.'.');
+                    $jobShares[$name] = $targetPercent;
+                    $jobIncreases[$name] = ['from' => $runningPercent, 'to' => $targetPercent];
                 }
+            }
+            if (count($jobIncreases)) {
+                $logger->info('[AIMD] Job profile changed, increases: ', $jobIncreases);
             }
 
             foreach ($jobsToRun as $job) {

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -305,7 +305,6 @@ try {
                 $targetPercent = $count / max($targetTotal, 1);
                 $runningPercent = ($runningCounts[$name] ?? 0) / max($runningTotal, 1);
                 if ($runningPercent + $profileChangeThreshold < $targetPercent) {
-                    $jobShares[$name] = $targetPercent;
                     $jobIncreases[$name] = ['from' => $runningPercent, 'to' => $targetPercent];
                 }
             }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.9.9",
+    "version": "1.9.10",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
More logging trying to figure out how to detect when the spikes here start:
https://github.com/Expensify/Expensify/issues/177470

Tested locally and seems to work fine:
```
2021-09-28T19:46:33.307481+00:00 expensidev2004 php: 1IXrYx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [dbug] _send( expensidev2004.web.bedrock.jobs.GetJobs:8|ms )
2021-09-28T19:46:33.307667+00:00 expensidev2004 php: 1IXrYx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [dbug] _send( expensidev2004.web.bedrockJob.call.response.GetJobs200:1|c )
2021-09-28T19:46:33.307737+00:00 expensidev2004 php: 1IXrYx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] [AIMD] current jobs (running): ~~ fakeA: '1'
2021-09-28T19:46:33.313123+00:00 expensidev2004 php: 1IXrYx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] [AIMD] current jobs (target): ~~ fakeA: '3' fakeB: '3'
2021-09-28T19:46:33.313327+00:00 expensidev2004 php: 1IXrYx vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] [AIMD] Job profile changed, increases:  ~~ fakeB: '[from: '0' to: '0.5']'
```