### PR TITLE
Add new constant for job priority

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.9.13",
+    "version": "1.9.14",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -80,6 +80,11 @@ class Jobs extends Plugin
     const PRIORITY_LOW = 0;
 
     /**
+     * Constant for the minimum priority.
+     */
+    const PRIORITY_MIN = 0;
+
+    /**
      * Constant for the location of the file to look for to disable processing
      * new jobs.
      */


### PR DESCRIPTION
We add a new constant for job priority 0. Update all occurrences in Web-E and then update `PRIORITY_LOW` to 250.

Required for https://github.com/Expensify/Web-Expensify/pull/32667
Slack discussion https://expensify.slack.com/archives/C03TQ48KC/p1640954580274500