### PR TITLE
Use new constants for job priorities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.9.14",
+    "version": "1.9.15",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -82,7 +82,32 @@ class Jobs extends Plugin
     /**
      * Constant for the minimum priority.
      */
-    const PRIORITY_MIN = 0;
+    const PRIORITY_0 = 0;
+
+    /**
+     * Constant for the low priority.
+     */
+    const PRIORITY_250 = 250;
+
+    /**
+     * Constant for the medium priority.
+     */
+    const PRIORITY_500 = 500;
+
+    /**
+     * Constant for the high priority.
+     */
+    const PRIORITY_750 = 750;
+
+    /**
+     * Constant for the higher priority.
+     */
+    const PRIORITY_850 = 850;
+
+    /**
+     * Constant for the maximum priority.
+     */
+    const PRIORITY_1000 = 1000;
 
     /**
      * Constant for the location of the file to look for to disable processing


### PR DESCRIPTION
As we started supporting new job priorities, we need to add and update constants
It also reverts the constant added [here](https://github.com/Expensify/Bedrock-PHP/pull/176) as we lately decided to use constant names such as PRIORITY_0 and so.

Required for Expensify/Web-Expensify#32667
Slack discussion https://expensify.slack.com/archives/C03TQ48KC/p1640954580274500