### PR TITLE
Add a random wait before restarting

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -635,8 +635,6 @@ function getNumberOfJobsToQueue(): int
  *
  * Note: php's filemtime results are cached, so we need to clear
  *       that cache or we'll be getting a stale modified time.
- *
- * @param Expensify\Bedrock\Stats\StatsInterface $stats
  */
 function checkVersionFile(string $versionWatchFile, int $versionWatchFileTimestamp, LoggerInterface $logger): bool
 {


### PR DESCRIPTION
Tests:
- Started BWM
- Touched the restart file
- Check it logs 
```
2022-05-06T15:44:01.333973+00:00 expensidev2004 php: m7KoMw vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Version watch file changed, will stop processing new jobs soon ~~ wait: '53'
```
- Wait a bit, check it logs:
```
[2022-05-06T15:44:57.579356+00:00 expensidev2004 php: m7KoMw vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Version watch file changed and wait time is over, stop processing new jobs
2022-05-06T15:44:57.579646+00:00 expensidev2004 php: m7KoMw vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Version watch file changed, stop processing new jobs
2022-05-06T15:44:57.579740+00:00 expensidev2004 php: m7KoMw vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Stopping BedrockWorkerManager, waiting for children
```