### PR TITLE
Do not wait for BWM children

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -502,11 +502,7 @@ try {
     echo "Error: $message\r\n";
 }
 
-// We wait for all children to finish before dying.
-$logger->info('Stopping BedrockWorkerManager, waiting for children');
-$status = null;
-pcntl_wait($status);
-$logger->info('Stopped BedrockWorkerManager');
+$logger->info('Stopped BedrockWorkerManager, will not wait for children');
 
 /**
  * Determines whether or not we call GetJob and try to start a new job

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -169,7 +169,9 @@ try {
             if ($load > $maxLoad) {
                 $logger->info('[AIMD] Not safe to start a new job, load is too high, waiting 1s and trying again.', ['load' => $load, 'MAX_LOAD' => $maxLoad]);
                 sleep(1);
-            } elseif ($jobsToQueue > $minSafeJobs / 2) {
+            } elseif ($jobsToQueue >= 3) {
+                // We ensure we ask minimum 3 jobs per GetJobs call, to avoid running tons of GetJobs calls back to back
+                // to return just 1 job
                 $logger->info('[AIMD] Safe to start a new job, checking for more work', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 $stats->counter('bedrockWorkerManager.currentJobsToQueue', $jobsToQueue);
                 $stats->counter('bedrockWorkerManager.targetJobsToQueue', $target);


### PR DESCRIPTION
# Issue

$ https://github.com/Expensify/Expensify/issues/209619

This does 2 things:
1. Does not wait for children to finish before exiting from the main bwm process. This allows us to re-start a new BWM instance immediately
2. It changes the minimum jobs to dequeue from 6 to 3 (before it had to be `> minSafeJobs / 2` and minSafeJobs is set to 10)

# Tests

- Start BWM
- See it starts some children
- Send the stop signal
- Check BWM main process finishes
- Check the children keep running and finish

