### PR TITLE
Re-seed random numbers with each new child PID

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -369,6 +369,10 @@ try {
                         $bedrock->commitCount = $commitCount;
                         $jobs = new Jobs($bedrock);
 
+                        // For each child PID, we need a fresh random seed to prevent duplicate "random" numbers generated.
+                        // Otherwise similar jobs run in the same BWM batch that call rand() will return the same result.
+                        mt_srand();
+
                         // If we are using a global REQUEST_ID, reset it to indicate this is a new process.
                         if (isset($GLOBALS['REQUEST_ID'])) {
                             // Reset the REQUEST_ID and re-log the line so we see

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/Bedrock-PHP",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "1.9.19",
+    "version": "1.9.20",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
See this slack thread: https://expensify.slack.com/archives/CQG20GM7X/p1654787619165049

Basically each thread needs a new seed so that they don't produce identical random numbers. 