### PR TITLE
store response object not closure

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -66,7 +66,7 @@ class DB extends Plugin
                     'timeout' => $timeout,
                 ]
             ));
-        });
+        })();
 
         if ($response->getCode() === self::CODE_QUERY_FAILED) {
             throw new BedrockError($response->getCodeLine()." - ".$response->getError(), $response->getCode());

--- a/src/DB.php
+++ b/src/DB.php
@@ -66,7 +66,7 @@ class DB extends Plugin
                     'timeout' => $timeout,
                 ]
             ));
-        })();
+        });
 
         if ($response->getCode() === self::CODE_QUERY_FAILED) {
             throw new BedrockError($response->getCodeLine()." - ".$response->getError(), $response->getCode());

--- a/src/Stats/NullStats.php
+++ b/src/Stats/NullStats.php
@@ -14,5 +14,6 @@ class NullStats implements StatsInterface
 
     public function benchmark($name, callable $function)
     {
+        return $function();
     }
 }


### PR DESCRIPTION
I had to do this to get the code working properly on my side project. Without this, it was throwing an exception "Unable to call method getCode() on Closure object" or something similar. Might have something to do with me using PHP 8.1? LMK if I'm holding it wrong.