### PR TITLE
[QSP] Update PHP version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '8.1.16'
+  - '8.1.18'
 
 before_install:
   - cd ../ && composer self-update 2.2.1 && cd -


### PR DESCRIPTION
### Changes
We're updating PHP to version 8.1.18 as part of QSP. This makes Travis use the new version for tests.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/287532

### Tests
Make sure Travis tests pass

### Web QA
No QA
