### PR TITLE
Bump Travis for QSP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '8.1.18'
+  - '8.1.21'
 
 before_install:
   - cd ../ && composer self-update 2.2.1 && cd -


### PR DESCRIPTION
Simply bumps the Travis PHP version for QSP: https://github.com/Expensify/Expensify/issues/308605