### PR TITLE
Only set the commitCount when we do a write

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use Expensify\Bedrock\Stats\StatsInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Socket;
 
 /**
  * Client for communicating with bedrock.
@@ -63,7 +64,7 @@ class Client implements LoggerAwareInterface
     public $commitCount = null;
 
     /**
-     *  @var resource|\Socket|null Socket to the server.
+     *  @var resource|Socket|null Socket to the server.
      */
     private $socket = null;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -15,27 +15,27 @@ use Psr\Log\NullLogger;
  */
 class Client implements LoggerAwareInterface
 {
-    const HEADER_DELIMITER = "\r\n\r\n";
-    const HEADER_FIELD_SEPARATOR = "\r\n";
+    public const HEADER_DELIMITER = "\r\n\r\n";
+    public const HEADER_FIELD_SEPARATOR = "\r\n";
 
     /**
      * The length of each packet read from the socket.
      */
-    const PACKET_LENGTH = 16384;
+    public const PACKET_LENGTH = 16384;
 
     /**
      * The prefix to use in apcu to store the state of the hosts.
      */
-    const APCU_CACHE_PREFIX = 'bedrockHostConfigs-';
+    public const APCU_CACHE_PREFIX = 'bedrockHostConfigs-';
 
     /**
      * Priorities a command can have.
      */
-    const PRIORITY_MIN = 0;
-    const PRIORITY_LOW = 250;
-    const PRIORITY_NORMAL = 500;
-    const PRIORITY_HIGH = 750;
-    const PRIORITY_MAX = 1000;
+    public const PRIORITY_MIN = 0;
+    public const PRIORITY_LOW = 250;
+    public const PRIORITY_NORMAL = 500;
+    public const PRIORITY_HIGH = 750;
+    public const PRIORITY_MAX = 1000;
 
     /**
      * @var array This is a default configuration applied to all instances of this class. They can be overriden in the
@@ -63,12 +63,12 @@ class Client implements LoggerAwareInterface
     public $commitCount = null;
 
     /**
-     *  @var resource|null Socket to the server.
+     *  @var resource|\Socket|null Socket to the server.
      */
     private $socket = null;
 
     /**
-     * @var null|string Name of the bedrock cluster we are talking to. If you have more than one bedrock cluster, you
+     * @var string|null Name of the bedrock cluster we are talking to. If you have more than one bedrock cluster, you
      *                  can pass in different names for them in order to have separate statistics collected and caches of failed servers.
      */
     private $clusterName = null;
@@ -261,8 +261,6 @@ class Client implements LoggerAwareInterface
 
     /**
      * Sets a logger instance on the object.
-     *
-     * @param LoggerInterface $logger
      */
     public function setLogger(LoggerInterface $logger)
     {
@@ -359,7 +357,7 @@ class Client implements LoggerAwareInterface
         $rawRequest = "$method\r\n";
         foreach ($headers as $name => $value) {
             if (is_array($value) || is_object($value)) {
-                $rawRequest .= "$name: ".addcslashes(json_encode($value), "\\")."\r\n";
+                $rawRequest .= "$name: ".addcslashes(json_encode($value), '\\')."\r\n";
             } elseif (is_bool($value)) {
                 $rawRequest .= "$name: ".($value ? 'true' : 'false')."\r\n";
             } elseif ($value === null || $value === '') {
@@ -368,7 +366,7 @@ class Client implements LoggerAwareInterface
                 $rawRequest .= "$name: ".self::toUTF8(addcslashes($value, "\r\n\t\\"))."\r\n";
             }
         }
-        $rawRequest .= "Content-Length: ".strlen($body)."\r\n";
+        $rawRequest .= 'Content-Length: '.strlen($body)."\r\n";
         $rawRequest .= "\r\n";
         $rawRequest .= $body;
 
@@ -410,7 +408,7 @@ class Client implements LoggerAwareInterface
                 $hostName = $this->lastHost;
             } else {
                 // Try the first possible host.
-                $hostName = key($hostConfigs);
+                $hostName = (string) key($hostConfigs);
                 $this->lastHost = $hostName;
             }
             try {
@@ -688,8 +686,8 @@ class Client implements LoggerAwareInterface
         // are talking to.
         // We only set it if process time was returned, which means we did a write. We don't care about saving the commit
         // count for reads, since we did not change anything in the DB.
-        if (isset($responseHeaders["commitCount"]) && ($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0) {
-            $this->commitCount = (int) $responseHeaders["commitCount"];
+        if (isset($responseHeaders['commitCount']) && ($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0) {
+            $this->commitCount = (int) $responseHeaders['commitCount'];
         }
 
         // We treat a non-sqlite-query timeout as a ConnectionFailure.
@@ -759,7 +757,7 @@ class Client implements LoggerAwareInterface
         $responseHeaders = [];
         foreach ($responseHeaderLines as $responseHeaderLine) {
             // Try to split this line
-            $nameValue = explode(":", $responseHeaderLine, 2);
+            $nameValue = explode(':', $responseHeaderLine, 2);
             if (count($nameValue) === 2) {
                 $responseHeaders[trim($nameValue[0])] = trim($nameValue[1]);
             } elseif (strlen($responseHeaderLine)) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -684,9 +684,11 @@ class Client implements LoggerAwareInterface
             }
         } while (is_null($responseLength) || strlen($response) < $responseLength);
 
-        // If we received the commitCount, then save it for future requests. This is useful if for some reason we
-        // change the bedrock node we are talking to.
-        if (isset($responseHeaders["commitCount"])) {
+        // We save the commitCount for future requests. This is useful if for some reason we change the bedrock node we
+        // are talking to.
+        // We only set it if process time was returned, which means we did a write. We don't care about saving the commit
+        // count for reads, since we did not change anything in the DB.
+        if (isset($responseHeaders["commitCount"]) && ($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0) {
             $this->commitCount = (int) $responseHeaders["commitCount"];
         }
 


### PR DESCRIPTION
Only set the commitCount when we do a write, since when we just did a read there's no commit to be waiting for.

Context https://expensify.slack.com/archives/C05TD78MJH1/p1696527242392409?thread_ts=1696522633.446849&cid=C05TD78MJH1

Tests, you can see here a few commands that are not reads that receive but not pass a commitCount and every command after UpdateTransaction passing a commitCount:
```
2023-10-05T17:56:40.213106+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'UpdateReport' clusterName: 'auth' headers: '[total: '-300' currency: 'USD' cachedData: '<REDACTED>' reportActionListCount: '4' connection: 'forget' authToken: '<REDACTED>' reportID: '5192450703871025' idempotent: '1' logParam: 'ionatan@expensify.com' maxNumberOfUpdates: '500' requestID: 'ddyyIH' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
2023-10-05T17:56:40.213299+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2023-10-05T17:56:40.213407+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2023-10-05T17:56:40.213536+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1120'
2023-10-05T17:56:40.214129+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'UpdateReport' jsonCode: '202 Successfully queued' duration: '2' net: '2' wait: '0' proc: '0' commitCount: ''
2023-10-05T17:56:40.217837+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'Get' clusterName: 'auth' headers: '[transactionID: '3686300801100799295' limit: '1000' offset: '0' authToken: '<REDACTED>' returnValueList: 'transactionList' idempotent: '1' logParam: 'ionatan@expensify.com' maxNumberOfUpdates: '500' requestID: 'ddyyIH' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
2023-10-05T17:56:40.217975+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2023-10-05T17:56:40.218073+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2023-10-05T17:56:40.218173+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1120'
2023-10-05T17:56:40.220829+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'Get' jsonCode: '200 OK' duration: '3' net: '0.89' wait: '2.11' proc: '0' commitCount: ''
2023-10-05T17:56:40.224187+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'UpdateTransaction' clusterName: 'auth' headers: '[authToken: '<REDACTED>' transactionID: '3686300801100799295' created: '' merchant: '' amount: '-400' category: 'Uncategorized' comment: '{"comment":""}' tag: '' billable: 'false' reimbursable: 'true' updateOriginal: '' reliableUpdates: '1' currency: 'USD' logParam: 'ionatan@expensify.com' maxNumberOfUpdates: '500' requestID: 'ddyyIH' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
2023-10-05T17:56:40.224351+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2023-10-05T17:56:40.224468+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2023-10-05T17:56:40.224564+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1120'
2023-10-05T17:56:40.229411+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'UpdateTransaction' jsonCode: '200 OK' duration: '6' net: '1.732' wait: '2.091' proc: '2.177' commitCount: '70795'
2023-10-05T17:56:40.230290+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'Get' clusterName: 'auth' headers: '[reportIDList: '5192450703871025' authToken: '<REDACTED>' returnValueList: 'reportListBeta' idempotent: '1' logParam: 'ionatan@expensify.com' maxNumberOfUpdates: '500' commitCount: '70795' requestID: 'ddyyIH' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
2023-10-05T17:56:40.230407+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2023-10-05T17:56:40.230498+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2023-10-05T17:56:40.230591+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1120'
2023-10-05T17:56:40.233003+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'Get' jsonCode: '200 OK' duration: '3' net: '1.005' wait: '1.995' proc: '0' commitCount: '70795'
2023-10-05T17:56:40.233884+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'Get' clusterName: 'auth' headers: '[name: 'expensify_categorizationRules' authToken: '<REDACTED>' returnValueList: 'nameValuePairs' idempotent: '1' logParam: 'ionatan@expensify.com' maxNumberOfUpdates: '500' commitCount: '70795' requestID: 'ddyyIH' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
2023-10-05T17:56:40.233996+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2023-10-05T17:56:40.234076+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2023-10-05T17:56:40.234175+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1120'
2023-10-05T17:56:40.235810+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'Get' jsonCode: '200 OK' duration: '2' net: '0.769' wait: '1.231' proc: '0' commitCount: '70795'
2023-10-05T17:56:40.247452+00:00 expensidev2004 php-fpm: ddyyIH /api.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'Get' clusterName: 'auth' headers: '[authToken: '<REDACTED>' returnValueList: '' idempotent: '1' logParam: 'ionatan@expensify.com' maxNumberOfUpdates: '500' commitCount: '70795' requestID: 'ddyyIH' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
```