### PR TITLE
Need to enclose this in parens

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -687,7 +687,7 @@ class Client implements LoggerAwareInterface
         // are talking to.
         // We only set it if process time was returned, which means we did a write. We don't care about saving the commit
         // count for reads, since we did not change anything in the DB.
-        if (isset($responseHeaders['commitCount']) && ($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0) {
+        if (isset($responseHeaders['commitCount']) && (($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0)) {
             $this->commitCount = (int) $responseHeaders['commitCount'];
         }
 


### PR DESCRIPTION
$https://github.com/Expensify/Expensify/issues/323419

Missed the parenthesis when adding this here https://github.com/Expensify/Bedrock-PHP/pull/197 🤦 

See there for tests, but also: load https://www.expensify.com.dev/_utilities/dbStatus.php and check no warning or error appears