### PR TITLE
Update travis PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '8.1.21'
+  - '8.1.25'
 
 before_install:
   - cd ../ && composer self-update 2.2.1 && cd -


### PR DESCRIPTION
Update PHP for Travis to version 8.1.25 as per the instructions in the linked issue

https://github.com/Expensify/Expensify/issues/336493