### PR TITLE
Use JSON_PRESERVE_ZERO_FRACTION

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -358,7 +358,7 @@ class Client implements LoggerAwareInterface
         $rawRequest = "$method\r\n";
         foreach ($headers as $name => $value) {
             if (is_array($value) || is_object($value)) {
-                $rawRequest .= "$name: ".addcslashes(json_encode($value), '\\')."\r\n";
+                $rawRequest .= "$name: ".addcslashes(json_encode($value, JSON_PRESERVE_ZERO_FRACTION), '\\')."\r\n";
             } elseif (is_bool($value)) {
                 $rawRequest .= "$name: ".($value ? 'true' : 'false')."\r\n";
             } elseif ($value === null || $value === '') {

--- a/src/Client.php
+++ b/src/Client.php
@@ -358,6 +358,9 @@ class Client implements LoggerAwareInterface
         $rawRequest = "$method\r\n";
         foreach ($headers as $name => $value) {
             if (is_array($value) || is_object($value)) {
+                // Passing flag JSON_PRESERVE_ZERO_FRACTION because otherwise PHP will serialize floating numbers like 2.0 to 2 instead of 2.0.
+                // This can cause bugs in Auth since we can't know what type a float number will be and accessing an int with the accessor for
+                // floats (or vice versa) would throw.
                 $rawRequest .= "$name: ".addcslashes(json_encode($value, JSON_PRESERVE_ZERO_FRACTION), '\\')."\r\n";
             } elseif (is_bool($value)) {
                 $rawRequest .= "$name: ".($value ? 'true' : 'false')."\r\n";


### PR DESCRIPTION
PHP when serializing to JSON will strip the `.0` of floats making them look like integers. Then, when we parse these JSONs in Auth, they are parsed as INT instead of FLOAT.

Found this issue investigating: https://github.com/Expensify/App/issues/32824
Asked in slack about it here: https://expensify.slack.com/archives/C03TQ48KC/p1704906489753899

# Test

Check that you can't reproduce the bug in https://github.com/Expensify/App/issues/32824 and verify the distance request is created correctly

cc @johnmlee101 @iwiznia 