### PR TITLE
Retry '500 Internal Server Error'

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -700,6 +700,10 @@ class Client implements LoggerAwareInterface
             throw new ConnectionFailure('Internal Bedrock command timeout (555 Timeout)');
         }
 
+        if ($codeLine === '500 Internal Server Error') {
+            throw new BedrockError('Bedrock responded with 500 Internal Server Error');
+        }
+
         // We'll parse the body *only* if this is `application/json` or blank.
         $isJSON = !isset($responseHeaders['Content-Type']) || !strcasecmp($responseHeaders['Content-Type'], 'application/json');
 


### PR DESCRIPTION
cc @roryabraham @tylerkaraszewski 

Issue:
https://github.com/Expensify/Expensify/issues/328201

Discussion here: https://expensify.slack.com/archives/C03TQ48KC/p1704745068459599?thread_ts=1698081801.911129&cid=C03TQ48KC

Tests:
1. Before the change, the code ends up throwing an `ExpException` without retrying
2. After the change, the command gets retried as expected, and ends up throwing an `Expensify\Bedrock\Exceptions\ConnectionFailure` exception