### PR TITLE
Ensure we are passing `int` not `float` for `StatsD::counter()` in BWM

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -175,7 +175,7 @@ try {
                 // to return just 1 job
                 $logger->info('[AIMD] Safe to start a new job, checking for more work', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 $stats->counter('bedrockWorkerManager.currentJobsToQueue', $jobsToQueue);
-                $stats->counter('bedrockWorkerManager.targetJobsToQueue', $target);
+                $stats->counter('bedrockWorkerManager.targetJobsToQueue', (int) $target);
                 break;
             } else {
                 $logger->info('[AIMD] Not enough jobs to queue, waiting 0.5s and trying again.', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "authors": [
         {
             "name": "Expensify",


### PR DESCRIPTION
cc @iwiznia while I dev noticed that this will break the `counter()` call as `$target` can be a float. 

Couldn't find any other obvious examples.