### PR TITLE
Add $connection param so we can FORGET

### DIFF
--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -221,11 +221,12 @@ class Jobs extends Plugin
     /**
      * Schedules a list of jobs.
      *
-     * @param array $jobs JSON array containing each job. Each job should include the same parameters as jobs define in CreateJob
+     * @param array  $jobs JSON array containing each job. Each job should include the same parameters as jobs define in CreateJob
+     * @param string $connection  (optional) Specify 'Connection' header using constants defined in this class.
      *
      * @return array - contain the jobIDs with the unique identifier of the created jobs
      */
-    public function createJobs(array $jobs): array
+    public function createJobs(array $jobs, string $connection = self::CONNECTION_WAIT): array
     {
         $this->client->getLogger()->info("Create jobs", ['jobs' => $jobs]);
 
@@ -251,7 +252,8 @@ class Jobs extends Plugin
             [
                 'jobs' => $jobs,
                 'idempotent' => $areAllJobsUnique,
-            ]
+                'Connection' => $connection,
+            ],
         );
 
         $this->client->getLogger()->info('Jobs created', ['jobIDs' => $response['body']['jobIDs'] ?? null]);


### PR DESCRIPTION
cc @iwiznia 

We want to fire and forget when calling `$jobs->createJobs`, so adding that possibility.

Fixes: https://github.com/Expensify/Web-Expensify/pull/42008/files#r1612040929