### PR TITLE
Default to null for `port` in $cachedHostConfigs

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -590,7 +590,7 @@ class Client implements LoggerAwareInterface
             // If the hosts and ports in the cache don't match the ones in the config, reset the cache.
             $cachedHostsAndPorts = [];
             foreach ($cachedHostConfigs as $hostName => $config) {
-                $cachedHostsAndPorts[$hostName] = $config['port'];
+                $cachedHostsAndPorts[$hostName] = $config['port'] ?? null;
             }
             asort($cachedHostsAndPorts);
             $uncachedHostsAndPort = [];


### PR DESCRIPTION
Avoid creating a warning notification if the port is not defined. $cachedHostsAndPorts is still reset if the values don't match cc @flodnv 

$ https://github.com/Expensify/Expensify/issues/420450