### PR TITLE
Use passed priority if set instead of default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.0.10",
+    "version": "2.0.11",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -336,7 +336,7 @@ class Client implements LoggerAwareInterface
             $headers['mockRequest'] = true;
         }
 
-        if ($this->commandPriority) {
+        if ($this->commandPriority && !isset($headers['priority'])) {
             $headers['priority'] = $this->commandPriority;
         }
 


### PR DESCRIPTION
Context: https://expensify.slack.com/archives/C07PP7QV8P5/p1733157297373329?thread_ts=1733154064.466989&cid=C07PP7QV8P5

While testing this I realized that passing priority was completely broken as it was always getting replaced with the normal priority.

