### PR TITLE
Update GH actions cache to 4.2.0 as 4.0 is deprecated

### DIFF
--- a/.github/actions/composite/setup-composer-cache/action.yml
+++ b/.github/actions/composite/setup-composer-cache/action.yml
@@ -10,7 +10,7 @@ runs:
       shell: bash
 
     - name: Cache Composer Files
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4.2.0
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
https://github.com/actions/cache/discussions/1510

Its deprecated so we need to bump this