### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/actions/composite/setup-composer-cache/action.yml
+++ b/.github/actions/composite/setup-composer-cache/action.yml
@@ -10,7 +10,8 @@ runs:
       shell: bash
 
     - name: Cache Composer Files
-      uses: actions/cache@v4.2.0
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/bedrock-php.yml
+++ b/.github/workflows/bedrock-php.yml
@@ -17,7 +17,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: checkout
-      uses: actions/checkout@v4.1.0
+      # v4.1.0
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       with:
         # Set fetch-depth to 100 so that we can compare HEAD with a good chunk of git log history
         fetch-depth: 100
@@ -44,7 +45,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: checkout
-      uses: actions/checkout@v4.1.0
+      # v4.1.0
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       with:
         # Set fetch-depth to 100 so that we can compare HEAD with a good chunk of git log history
         fetch-depth: 100


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/CC7NECV4L/p1743022578963949, this pull request updates all mutable action references to use immutable commit hashes instead. This is a security measure to protect from supply chain attacks.