### PR TITLE
Log jobID before forking in bwm

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -333,6 +333,7 @@ try {
                     //       zombie process.)
                     $logger->info('Forking and running a worker.', [
                         'workerFileName' => $workerFilename,
+                        'jobID' => $job['jobID'],
                     ]);
 
                     // Do the fork


### PR DESCRIPTION
See https://github.com/Expensify/Expensify/issues/357691#issuecomment-3127334307

Tests:
```
2025-07-28T13:54:58.887637+00:00 expensidev-2404 php-fpm: VqGkUU vendor/bin/BedrockWorkerManager.php we@dont.know !script! ?api? [info] Forking and running a worker. ~~ workerFileName: '/vagrant/Web-Expensify/script/bwm//SendFetchableOnyxUpdates.php' jobID: '1093649887389681110'
```