### PR TITLE
Save commitCount when response says to

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -707,7 +707,7 @@ class Client implements LoggerAwareInterface
         // are talking to.
         // We only set it if process time was returned, which means we did a write. We don't care about saving the commit
         // count for reads, since we did not change anything in the DB.
-        if (isset($responseHeaders['commitCount']) && (($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0)) {
+        if ($responseHeaders['shouldSaveCommitCount'] ?? false || (isset($responseHeaders['commitCount']) && (($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0))) {
             $this->commitCount = (int) $responseHeaders['commitCount'];
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -703,10 +703,9 @@ class Client implements LoggerAwareInterface
             }
         } while (is_null($responseLength) || strlen($response) < $responseLength);
 
-        // We save the commitCount for future requests. This is useful if for some reason we change the bedrock node we
-        // are talking to.
-        // We only set it if process time was returned, which means we did a write. We don't care about saving the commit
-        // count for reads, since we did not change anything in the DB.
+        // Save the commit count if needed.
+        // In some cases, Auth will return a header instructing the client to save the commit count. It is useful for determining if stale data was used for certain read commands.
+        // Commit counts are saved for all write commands, identified by process time being non-zero, because it can be useful for future requests if for some reason we change the bedrock node we are talking to.
         if ($responseHeaders['shouldSaveCommitCount'] ?? false || (isset($responseHeaders['commitCount']) && (($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0))) {
             $this->commitCount = (int) ($responseHeaders['commitCount'] ?? 0);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -708,7 +708,7 @@ class Client implements LoggerAwareInterface
         // We only set it if process time was returned, which means we did a write. We don't care about saving the commit
         // count for reads, since we did not change anything in the DB.
         if ($responseHeaders['shouldSaveCommitCount'] ?? false || (isset($responseHeaders['commitCount']) && (($responseHeaders['processTime'] ?? 0) > 0 || ($responseHeaders['upstreamProcessTime'] ?? 0) > 0))) {
-            $this->commitCount = (int) $responseHeaders['commitCount'];
+            $this->commitCount = (int) ($responseHeaders['commitCount'] ?? 0);
         }
 
         // We treat this '555 Timeout', which is a command timeout (not a query timeout), as a ConnectionFailure so that it gets retried regardless of if it is idempotent or not.


### PR DESCRIPTION
# Explanation of change
In the related issue, we are logging differences between the report title that is calculated according to the custom formula by Auth and by Web Expensify. I am pretty sure that this is happening because Web Expensify is using stale report data when it computes the title and Auth is using up-to-date data. In order to be able to ignore these logs, we are going to include the commit count when the report was loaded and the commit count that Auth used when computing the title. With that information, we can easily see when the title would have been computed correctly if not for the fact that it is using stale data.

Currently Bedrock-PHP only saves the commitCount for write commands, but in order to keep track of the commitCount when reports are loaded, it needs to be saved for all report load requests. Therefore, let's add a flag that can be set in an Auth response to explicitly tell BedrockPHP to save the commit count.

# Related Issues
https://github.com/Expensify/Expensify/issues/540370

# Tests
This PR will be tested along with the [Web-E PR](https://github.com/Expensify/Web-Expensify/pull/48373). Please see the tests there.