### PR TITLE
Clean up old TRAVIS_* envvars

### DIFF
--- a/ci/phan.php
+++ b/ci/phan.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 require realpath(dirname(__FILE__)).'/../vendor/autoload.php';
 use Expensify\Bedrock\CI\PhanAnalyzer;
 
-$analyzer = new PhanAnalyzer($_SERVER['TRAVIS_BRANCH']);
+$analyzer = new PhanAnalyzer($_SERVER['GITHUB_REF']);
 if ($analyzer->analyze()) {
     exit(0);
 } else {

--- a/ci/src/PHPStyler.php
+++ b/ci/src/PHPStyler.php
@@ -8,12 +8,12 @@ namespace Expensify\Bedrock\CI;
 class PHPStyler extends CommandLine
 {
     /**
-     * @var string Branch we are checking (usually coming from['TRAVIS_BRANCH'])
+     * @var string Branch we are checking (usually coming from['GITHUB_REF'])
      */
     private $branch;
 
     /**
-     * @var string Commit we are checking (usually coming from['TRAVIS_COMMIT'])
+     * @var string Commit we are checking (usually coming from['GITHUB_SHA'])
      */
     private $commit;
 

--- a/ci/src/PhanAnalyzer.php
+++ b/ci/src/PhanAnalyzer.php
@@ -8,7 +8,7 @@ namespace Expensify\Bedrock\CI;
 class PhanAnalyzer extends CommandLine
 {
     /**
-     * @var string Branch we are checking (usually coming from['TRAVIS_BRANCH'])
+     * @var string Branch we are checking (usually coming from['GITHUB_REF'])
      */
     private $branch;
 

--- a/ci/style.php
+++ b/ci/style.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 require realpath(dirname(__FILE__)).'/../vendor/autoload.php';
 use Expensify\Bedrock\CI\PHPStyler;
 
-$styler = new PHPStyler($_SERVER['TRAVIS_BRANCH'], $_SERVER['TRAVIS_COMMIT']);
+$styler = new PHPStyler($_SERVER['GITHUB_REF'], $_SERVER['GITHUB_SHA']);
 $valid = $styler->check();
 exit((int) !$valid);

--- a/src/Client.php
+++ b/src/Client.php
@@ -607,7 +607,7 @@ class Client implements LoggerAwareInterface
      * @param ?string $preferredHost If passed, it will prefer this host over any of the configured ones. This does not
      *                               ensure it will use that host, but it will try to use it if its not blacklisted.
      *
-     * @suppress PhanUndeclaredConstant - suppresses TRAVIS_RUNNING
+     * @suppress PhanUndeclaredConstant - suppresses GITHUB_RUNNING
      */
     private function getPossibleHosts(?string $preferredHost, bool $resetHosts = false)
     {
@@ -838,12 +838,12 @@ class Client implements LoggerAwareInterface
      * configuration.
      * We also close and clear the socket from the cache, so we don't reuse it.
      *
-     * @suppress PhanUndeclaredConstant - suppresses TRAVIS_RUNNING
+     * @suppress PhanUndeclaredConstant - suppresses GITHUB_RUNNING
      */
     private function markHostAsFailed(string $host)
     {
         $blacklistedUntil = time() + rand(1, $this->maxBlackListTimeout);
-        if (!defined('TRAVIS_RUNNING') || !TRAVIS_RUNNING) {
+        if (!defined('GITHUB_RUNNING') || !GITHUB_RUNNING) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;
             $hostConfigs = apcu_fetch($apcuKey);
             $hostConfigs[$host]['blacklistedUntil'] = $blacklistedUntil;

--- a/src/Client.php
+++ b/src/Client.php
@@ -614,7 +614,7 @@ class Client implements LoggerAwareInterface
         // We get the host configs from the APC cache. Then, we check the configuration there with the passed
         // configuration and if it's outdated (ie: it has different hosts from the one in the config), we reset it. This
         // is so that we don't keep the old cache after changing the hosts or failover configuration.
-        if (!defined('TRAVIS_RUNNING') || !TRAVIS_RUNNING) {
+        if (!defined('GITHUB_RUNNING') || !GITHUB_RUNNING) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;
             if ($resetHosts) {
                 $this->logger->info('Bedrock\Client - Resetting host configs');


### PR DESCRIPTION
We no longer use TravisCI, so these envvars had their values patched over from GITHUB envvars.  It makes more sense to use the correct envvars initially.

Fixes: https://github.com/Expensify/Expensify/issues/514581#issuecomment-3329458321


<!-- Assign PullerBear for review and anyone else that knows the area or changes well. -->

# Explanation of Change

<!-- Explain what your change does and how it addresses the linked issue -->

Mapping: 
```
TRAVIS_RUNNING - (bool) getenv('GITHUB_SHA'))
TRAVIS_COMMIT - GITHUB_SHA
TRAVIS_BRANCH - GITHUB_REF
```

### Related Issues

## Deployment

- [ ] I followed the steps in the [README](../README.md#publishing-your-changes) to ensure this PR is deployed properly