### PR TITLE
Fix link to `README` in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
 
 ## Deployment
 
-- [ ] I followed the steps in the [README](../README.md#publishing-your-changes) to ensure this PR is deployed properly
+- [ ] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly


### PR DESCRIPTION
### Explanation of Change

Minor update to fix the link to the README in the PR template. The current relative link points to https://github.com/Expensify/Bedrock-PHP/README.md, which is 404.

### Related Issues

N/A

## Deployment

- :x: I followed the steps in the [README](../README.md#publishing-your-changes) to ensure this PR is deployed properly