### PR TITLE
Publish expensidev-php image on Bedrock-PHP main pushes

### DIFF
--- a/.github/workflows/publish-expensidev-php-image.yml
+++ b/.github/workflows/publish-expensidev-php-image.yml
@@ -1,0 +1,108 @@
+name: Publish Expensidev PHP Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-expensidev-php-image
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/expensify/expensidev-php
+  CHECKOUT_TOKEN: ${{ secrets.MELVIN_GH_TOKEN || secrets.CODE_EXPENSIFY_TOKEN || github.token }}
+
+jobs:
+  build-amd64:
+    name: Build amd64
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 90
+    steps:
+      - name: Checkout Expensidev
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: Expensify/Expensidev
+          ref: main
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Expensidev
+
+      - name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@33fed32c1ba8775f20366ec9e8d0cd9fe8fc1dd3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Build and push amd64 image
+        uses: useblacksmith/build-push-action@8be78d7cc5f972bb9f88f73f3ad84fc59fdd0bf8
+        with:
+          context: Expensidev
+          file: Expensidev/ci/docker/Dockerfile.php
+          push: true
+          provenance: false
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_NAME }}:latest-amd64
+
+  build-arm64:
+    name: Build arm64
+    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
+    timeout-minutes: 90
+    steps:
+      - name: Checkout Expensidev
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: Expensify/Expensidev
+          ref: main
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Expensidev
+
+      - name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@33fed32c1ba8775f20366ec9e8d0cd9fe8fc1dd3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Build and push arm64 image
+        uses: useblacksmith/build-push-action@8be78d7cc5f972bb9f88f73f3ad84fc59fdd0bf8
+        with:
+          context: Expensidev
+          file: Expensidev/ci/docker/Dockerfile.php
+          push: true
+          provenance: false
+          platforms: linux/arm64
+          tags: ${{ env.IMAGE_NAME }}:latest-arm64
+
+  publish-manifest:
+    name: Publish multi-arch manifest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: [build-amd64, build-arm64]
+    steps:
+      - name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@33fed32c1ba8775f20366ec9e8d0cd9fe8fc1dd3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ env.CHECKOUT_TOKEN }}
+
+      - name: Publish latest manifest
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ env.IMAGE_NAME }}:latest" \
+            "${{ env.IMAGE_NAME }}:latest-amd64" \
+            "${{ env.IMAGE_NAME }}:latest-arm64"

--- a/.github/workflows/publish-expensidev-php-image.yml
+++ b/.github/workflows/publish-expensidev-php-image.yml
@@ -19,10 +19,20 @@ env:
   CHECKOUT_TOKEN: ${{ secrets.MELVIN_GH_TOKEN || secrets.CODE_EXPENSIFY_TOKEN || github.token }}
 
 jobs:
-  build-amd64:
-    name: Build amd64
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+  build:
+    name: Build ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: blacksmith-32vcpu-ubuntu-2404
+            platform: linux/amd64
+          - arch: arm64
+            runner: blacksmith-32vcpu-ubuntu-2404-arm
+            platform: linux/arm64
     steps:
       - name: Checkout Expensidev
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -42,53 +52,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ env.CHECKOUT_TOKEN }}
 
-      - name: Build and push amd64 image
+      - name: Build and push image
         uses: useblacksmith/build-push-action@8be78d7cc5f972bb9f88f73f3ad84fc59fdd0bf8
         with:
           context: Expensidev
           file: Expensidev/ci/docker/Dockerfile.php
           push: true
           provenance: false
-          platforms: linux/amd64
-          tags: ${{ env.IMAGE_NAME }}:latest-amd64
-
-  build-arm64:
-    name: Build arm64
-    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
-    timeout-minutes: 90
-    steps:
-      - name: Checkout Expensidev
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          repository: Expensify/Expensidev
-          ref: main
-          token: ${{ env.CHECKOUT_TOKEN }}
-          path: Expensidev
-
-      - name: Setup Docker Builder
-        uses: useblacksmith/setup-docker-builder@33fed32c1ba8775f20366ec9e8d0cd9fe8fc1dd3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ env.CHECKOUT_TOKEN }}
-
-      - name: Build and push arm64 image
-        uses: useblacksmith/build-push-action@8be78d7cc5f972bb9f88f73f3ad84fc59fdd0bf8
-        with:
-          context: Expensidev
-          file: Expensidev/ci/docker/Dockerfile.php
-          push: true
-          provenance: false
-          platforms: linux/arm64
-          tags: ${{ env.IMAGE_NAME }}:latest-arm64
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }}
 
   publish-manifest:
     name: Publish multi-arch manifest
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    needs: [build-amd64, build-arm64]
+    needs: [build]
     steps:
       - name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@33fed32c1ba8775f20366ec9e8d0cd9fe8fc1dd3


### PR DESCRIPTION
# Explanation of Change
Add a workflow to publish multi-arch `ghcr.io/expensify/expensidev-php` tags when Bedrock-PHP updates are pushed to main.

### Related Issues
https://github.com/Expensify/Expensify/issues/605417

## Deployment

- [ ] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly

Made with [Cursor](https://cursor.com)