### PR TITLE
Remove retry-everyone-when-down behavior in bedrock client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.2.10",
+    "version": "2.3.0",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -410,7 +410,6 @@ class Client implements LoggerAwareInterface
         }
 
         $hostName = null;
-        $retriedAllHosts = false;
         while (!$response && count($hostConfigs)) {
             $exception = null;
             reset($hostConfigs);
@@ -444,11 +443,7 @@ class Client implements LoggerAwareInterface
                 if ($numRetriesLeft) {
                     $this->logger->info('Bedrock\Client - Failed to connect or send the request; retrying', ['host' => $hostName, 'message' => $e->getMessage(), 'retriesLeft' => $numRetriesLeft, 'exception' => $e]);
                 } else {
-                    if ($retriedAllHosts) {
-                        $this->logger->error('Bedrock\Client - Failed to connect or send the request; not retrying because we are out of retries', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
-                    } else {
-                        $this->logger->info('Bedrock\Client - Failed to connect or send the request; retrying in all hosts', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
-                    }
+                    $this->logger->error('Bedrock\Client - Failed to connect or send the request; not retrying because we are out of retries', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
                     $exception = $e;
                 }
             } catch (BedrockError $e) {
@@ -462,11 +457,7 @@ class Client implements LoggerAwareInterface
                 if ($numRetriesLeft) {
                     $this->logger->info('Bedrock\Client - Failed to send the whole request or to receive it; retrying because command is idempotent', ['host' => $hostName, 'message' => $e->getMessage(), 'retriesLeft' => $numRetriesLeft, 'exception' => $e]);
                 } else {
-                    if ($retriedAllHosts) {
-                        $this->logger->error('Bedrock\Client - Failed to send the whole request or to receive it; not retrying because we are out of retries', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
-                    } else {
-                        $this->logger->info('Bedrock\Client - Failed to send the whole request or to receive it; retrying in all hosts', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
-                    }
+                    $this->logger->error('Bedrock\Client - Failed to send the whole request or to receive it; not retrying because we are out of retries', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
                     $exception = $e;
                 }
             } finally {
@@ -476,20 +467,8 @@ class Client implements LoggerAwareInterface
                 }, ARRAY_FILTER_USE_KEY);
             }
 
-            // All non blacklisted hosts failed, this could be because we are in the middle of a cluster version flip.
-            // ie: We have version 1 and version 2, we've installed version 2 in less than half the cluster, a previous
-            // request already marked all servers in version 2 as failed (since 1 is the current version) in this request
-            // we have installed version 2 in one more server, making it the current version. So now all the servers that
-            // were marked as failed in the previous request are the ones serving requests and all the ones that were good
-            // before are now in the old version and not serving requests. So to cover this, we retry in all servers
-            // once hoping it will find a server that works.
             if ($exception) {
-                if ($retriedAllHosts) {
-                    throw $exception;
-                }
-                $retriedAllHosts = true;
-                $this->logger->info('All non blacklisted hosts failed, as a last resort try again in all hosts');
-                $hostConfigs = $this->getPossibleHosts($preferredHost, true);
+                throw $exception;
             }
         }
 
@@ -614,19 +593,14 @@ class Client implements LoggerAwareInterface
      *
      * @suppress PhanUndeclaredConstant - suppresses ARE_GITHUB_ACTIONS_RUNNING
      */
-    private function getPossibleHosts(?string $preferredHost, bool $resetHosts = false)
+    private function getPossibleHosts(?string $preferredHost)
     {
         // We get the host configs from the APC cache. Then, we check the configuration there with the passed
         // configuration and if it's outdated (ie: it has different hosts from the one in the config), we reset it. This
         // is so that we don't keep the old cache after changing the hosts or failover configuration.
         if (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;
-            if ($resetHosts) {
-                $this->logger->info('Bedrock\Client - Resetting host configs');
-                $cachedHostConfigs = [];
-            } else {
-                $cachedHostConfigs = apcu_fetch($apcuKey) ?: [];
-            }
+            $cachedHostConfigs = apcu_fetch($apcuKey) ?: [];
             $this->logger->debug('Bedrock\Client - APC fetch host configs', array_keys($cachedHostConfigs));
 
             // If the hosts and ports in the cache don't match the ones in the config, reset the cache.


### PR DESCRIPTION
More context https://expensify.slack.com/archives/C05CBC62HGW/p1782740514654479

# Explanation of Change

This PR removes the retry all hosts logic we previously had implemented. This was initially implemented to account for the situations where we were deploying and half of the nodes were unavailable, and the immediately we had the other half unavailable. That would make our logic basically have no hosts for a few seconds.

That doesn't happen anymore because unavailable hosts will forward the request to an available host.

### Related Issues

https://github.com/Expensify/Expensify/issues/649214

## Deployment

- [x] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
