### PR TITLE
Do not blacklist server if maxBlackListTimeout is 0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -830,8 +830,7 @@ class Client implements LoggerAwareInterface
         if (!$this->maxBlackListTimeout) {
             return;
         }
-        $blacklistLength = rand(1, $this->maxBlackListTimeout);
-        $blacklistedUntil = time() + $blacklistLength;
+        $blacklistedUntil = time() + rand(1, $this->maxBlackListTimeout);
         if (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;
             $hostConfigs = apcu_fetch($apcuKey);

--- a/src/Client.php
+++ b/src/Client.php
@@ -827,7 +827,11 @@ class Client implements LoggerAwareInterface
      */
     private function markHostAsFailed(string $host)
     {
-        $blacklistedUntil = time() + rand(1, $this->maxBlackListTimeout);
+        $blacklistLength = min(rand(1, $this->maxBlackListTimeout), $this->maxBlackListTimeout);
+        if (!$blacklistLength) {
+            return;
+        }
+        $blacklistedUntil = time() + $blacklistLength;
         if (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;
             $hostConfigs = apcu_fetch($apcuKey);

--- a/src/Client.php
+++ b/src/Client.php
@@ -827,10 +827,10 @@ class Client implements LoggerAwareInterface
      */
     private function markHostAsFailed(string $host)
     {
-        $blacklistLength = min(rand(1, $this->maxBlackListTimeout), $this->maxBlackListTimeout);
-        if (!$blacklistLength) {
+        if (!$this->maxBlackListTimeout) {
             return;
         }
+        $blacklistLength = rand(1, $this->maxBlackListTimeout);
         $blacklistedUntil = time() + $blacklistLength;
         if (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;


### PR DESCRIPTION
<!-- Assign PullerBear for review and anyone else that knows the area or changes well. -->

# Explanation of Change

Related to https://github.com/Expensify/Web-Expensify/pull/54229 solves this:
> Does not blacklist the host.... well, there's actually an off by one error here, there's 50% chance we blacklist it for 1s [here](https://github.com/Expensify/Bedrock-PHP/blob/main/src/Client.php?rgh-link-date=2026-07-03T11%3A06%3A35Z#L830), LMK if you think I should send a PR to fix that (by doing max(rand(1, $this->maxBlackListTimeout), $this->maxBlackListTimeout))

