### PR TITLE
Add a circuit breaker to the Bedrock client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.2.10",
+    "version": "2.2.11",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -296,9 +296,9 @@ class Client implements LoggerAwareInterface
             'stats' => new NullStats(),
             'writeConsistency' => 'ASYNC',
             'maxBlackListTimeout' => 1,
-            'circuitBreakerThreshold' => 0,
-            'circuitBreakerCooldown' => 5,
-            'retryBudgetRatio' => 0,
+            'circuitBreakerThreshold' => 10,
+            'circuitBreakerCooldown' => 10,
+            'retryBudgetRatio' => 0.1,
             'commandPriority' => null,
             'logParam' => null,
         ], self::$defaultConfig, $config);

--- a/src/Client.php
+++ b/src/Client.php
@@ -347,9 +347,6 @@ class Client implements LoggerAwareInterface
      * @param string $body    Request body (optional)
      *
      * @return array JSON response
-     *
-     * @throws BedrockError
-     * @throws ConnectionFailure
      */
     public function call($method, $headers = [], $body = '')
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,16 +30,9 @@ class Client implements LoggerAwareInterface
     public const APCU_CACHE_PREFIX = 'bedrockHostConfigs-';
 
     /**
-     * APCu key prefixes for the (per-cluster, box-wide) circuit breaker and retry-budget state.
+     * APCu key prefix for the (per-cluster, box-wide) circuit breaker state.
      */
     public const CIRCUIT_BREAKER_CACHE_PREFIX = 'bedrockCircuitBreaker-';
-    public const RETRY_BUDGET_CACHE_PREFIX = 'bedrockRetryBudget-';
-
-    /**
-     * Attempts needed in the current minute before the retry-budget ratio is enforced (avoids a cold-start
-     * where a single early retry trips the ratio).
-     */
-    public const RETRY_BUDGET_MIN_SAMPLE = 100;
 
     /**
      * Priorities a command can have.
@@ -153,11 +146,6 @@ class Client implements LoggerAwareInterface
     private $circuitBreakerCooldown;
 
     /**
-     * @var float Max retries as a fraction of total attempts per cluster per minute (box-wide). 0 disables it.
-     */
-    private $retryBudgetRatio;
-
-    /**
      * @var bool Set this to true to add a `mockRequest` header to all outgoing requests.
      */
     private $mockRequests;
@@ -198,7 +186,6 @@ class Client implements LoggerAwareInterface
      *                      string|null          logParam            Extra data to add to the bedrock logs
      *                      int|null             circuitBreakerThreshold Cluster-unreachable failures before the breaker opens (0 disables)
      *                      int|null             circuitBreakerCooldown  Seconds the breaker stays open once tripped
-     *                      float|null           retryBudgetRatio        Max retries as a fraction of attempts/cluster/minute (0 disables)
      *
      * @throws BedrockError
      */
@@ -219,7 +206,6 @@ class Client implements LoggerAwareInterface
         $this->maxBlackListTimeout = $config['maxBlackListTimeout'];
         $this->circuitBreakerThreshold = $config['circuitBreakerThreshold'];
         $this->circuitBreakerCooldown = $config['circuitBreakerCooldown'];
-        $this->retryBudgetRatio = $config['retryBudgetRatio'];
         $this->commandPriority = $config['commandPriority'];
         $this->logParam = $config['logParam'];
 
@@ -298,7 +284,6 @@ class Client implements LoggerAwareInterface
             'maxBlackListTimeout' => 1,
             'circuitBreakerThreshold' => 10,
             'circuitBreakerCooldown' => 10,
-            'retryBudgetRatio' => 0.1,
             'commandPriority' => null,
             'logParam' => null,
         ], self::$defaultConfig, $config);
@@ -479,16 +464,7 @@ class Client implements LoggerAwareInterface
         }
 
         $hostName = null;
-        $attempt = 0;
         while (!$response && count($hostConfigs)) {
-            // Every attempt after the first is a retry; a box-wide retry budget keeps a cluster-wide
-            // outage from turning each request into a burst of cross-host retries (retry amplification).
-            if ($attempt > 0 && !$this->consumeRetryBudget()) {
-                $this->logger->info('Bedrock\Client - Retry budget exhausted, not retrying', ['clusterName' => $this->clusterName]);
-                break;
-            }
-            $this->recordAttempt();
-            $attempt++;
             $exception = null;
             reset($hostConfigs);
             $numRetriesLeft = count($hostConfigs) - 1;
@@ -978,41 +954,6 @@ class Client implements LoggerAwareInterface
         }
         apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails');
         apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open');
-    }
-
-    /**
-     * Counts one attempt (first try or retry) toward the current minute's box-wide retry-budget window.
-     */
-    private function recordAttempt(): void
-    {
-        if ($this->retryBudgetRatio <= 0 || !$this->apcuAvailable()) {
-            return;
-        }
-        $success = false;
-        apcu_inc(self::RETRY_BUDGET_CACHE_PREFIX.$this->clusterName.'-att-'.floor(time() / 60), 1, $success, 120);
-    }
-
-    /**
-     * Enforces a box-wide retry budget: retries are allowed only while they stay under retryBudgetRatio of
-     * total attempts this minute, capping retry amplification during an outage without throttling normal
-     * failover. Returns true when a retry is permitted.
-     */
-    private function consumeRetryBudget(): bool
-    {
-        if ($this->retryBudgetRatio <= 0 || !$this->apcuAvailable()) {
-            return true;
-        }
-        $minute = floor(time() / 60);
-        $attempts = apcu_fetch(self::RETRY_BUDGET_CACHE_PREFIX.$this->clusterName.'-att-'.$minute) ?: 0;
-        $success = false;
-        $retries = apcu_inc(self::RETRY_BUDGET_CACHE_PREFIX.$this->clusterName.'-ret-'.$minute, 1, $success, 120);
-
-        // Allow retries freely until there's a meaningful sample this minute; low traffic can't storm anyway.
-        if ($attempts < self::RETRY_BUDGET_MIN_SAMPLE) {
-            return true;
-        }
-
-        return ($retries / $attempts) <= $this->retryBudgetRatio;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,6 +30,18 @@ class Client implements LoggerAwareInterface
     public const APCU_CACHE_PREFIX = 'bedrockHostConfigs-';
 
     /**
+     * APCu key prefixes for the (per-cluster, box-wide) circuit breaker and retry-budget state.
+     */
+    public const CIRCUIT_BREAKER_CACHE_PREFIX = 'bedrockCircuitBreaker-';
+    public const RETRY_BUDGET_CACHE_PREFIX = 'bedrockRetryBudget-';
+
+    /**
+     * Attempts needed in the current minute before the retry-budget ratio is enforced (avoids a cold-start
+     * where a single early retry trips the ratio).
+     */
+    public const RETRY_BUDGET_MIN_SAMPLE = 100;
+
+    /**
      * Priorities a command can have.
      */
     public const PRIORITY_MIN = 0;
@@ -131,6 +143,21 @@ class Client implements LoggerAwareInterface
     private $maxBlackListTimeout;
 
     /**
+     * @var int Consecutive cluster-unreachable failures before the circuit breaker opens. 0 disables it.
+     */
+    private $circuitBreakerThreshold;
+
+    /**
+     * @var int Seconds the circuit breaker stays open (failing fast) once tripped.
+     */
+    private $circuitBreakerCooldown;
+
+    /**
+     * @var float Max retries as a fraction of total attempts per cluster per minute (box-wide). 0 disables it.
+     */
+    private $retryBudgetRatio;
+
+    /**
      * @var bool Set this to true to add a `mockRequest` header to all outgoing requests.
      */
     private $mockRequests;
@@ -169,6 +196,9 @@ class Client implements LoggerAwareInterface
      *                      int|null             maxBlackListTimeout When a host fails, it will blacklist it and not try to reuse it for up to this amount of seconds.
      *                      int|null             commandPriority     The priority to send the commands with
      *                      string|null          logParam            Extra data to add to the bedrock logs
+     *                      int|null             circuitBreakerThreshold Cluster-unreachable failures before the breaker opens (0 disables)
+     *                      int|null             circuitBreakerCooldown  Seconds the breaker stays open once tripped
+     *                      float|null           retryBudgetRatio        Max retries as a fraction of attempts/cluster/minute (0 disables)
      *
      * @throws BedrockError
      */
@@ -187,6 +217,9 @@ class Client implements LoggerAwareInterface
         $this->stats = $config['stats'];
         $this->writeConsistency = $config['writeConsistency'];
         $this->maxBlackListTimeout = $config['maxBlackListTimeout'];
+        $this->circuitBreakerThreshold = $config['circuitBreakerThreshold'];
+        $this->circuitBreakerCooldown = $config['circuitBreakerCooldown'];
+        $this->retryBudgetRatio = $config['retryBudgetRatio'];
         $this->commandPriority = $config['commandPriority'];
         $this->logParam = $config['logParam'];
 
@@ -263,6 +296,9 @@ class Client implements LoggerAwareInterface
             'stats' => new NullStats(),
             'writeConsistency' => 'ASYNC',
             'maxBlackListTimeout' => 1,
+            'circuitBreakerThreshold' => 0,
+            'circuitBreakerCooldown' => 5,
+            'retryBudgetRatio' => 0,
             'commandPriority' => null,
             'logParam' => null,
         ], self::$defaultConfig, $config);
@@ -315,6 +351,38 @@ class Client implements LoggerAwareInterface
     }
 
     /**
+     * Makes a call to Bedrock, guarded by a per-cluster circuit breaker: once the cluster has been
+     * repeatedly unreachable, calls fail fast instead of each tying up a worker until it exhausts every
+     * host. A ConnectionFailure (no usable response from any host) counts toward tripping the breaker;
+     * command-level BedrockErrors do not.
+     *
+     * @param string $method  Request method
+     * @param array  $headers Request headers (optional)
+     * @param string $body    Request body (optional)
+     *
+     * @return array JSON response
+     *
+     * @throws BedrockError
+     * @throws ConnectionFailure
+     */
+    public function call($method, $headers = [], $body = '')
+    {
+        if (!$this->circuitBreakerAllowsRequest()) {
+            $this->logger->info('Bedrock\Client - Circuit breaker open, failing fast', ['clusterName' => $this->clusterName]);
+            throw new ConnectionFailure("Bedrock circuit breaker open for cluster $this->clusterName");
+        }
+        try {
+            $response = $this->doCall($method, $headers, $body);
+        } catch (ConnectionFailure $e) {
+            $this->recordCircuitFailure();
+            throw $e;
+        }
+        $this->recordCircuitSuccess();
+
+        return $response;
+    }
+
+    /**
      * Makes a direct call to Bedrock.
      *
      * @param string $method  Request method
@@ -326,7 +394,7 @@ class Client implements LoggerAwareInterface
      * @throws BedrockError
      * @throws ConnectionFailure
      */
-    public function call($method, $headers = [], $body = '')
+    private function doCall($method, $headers = [], $body = '')
     {
         // Start timing the entire end-to-end
         $timeStart = microtime(true);
@@ -411,7 +479,16 @@ class Client implements LoggerAwareInterface
 
         $hostName = null;
         $retriedAllHosts = false;
+        $attempt = 0;
         while (!$response && count($hostConfigs)) {
+            // Every attempt after the first is a retry; a box-wide retry budget keeps a cluster-wide
+            // outage from turning each request into a burst of cross-host retries (retry amplification).
+            if ($attempt > 0 && !$this->consumeRetryBudget()) {
+                $this->logger->info('Bedrock\Client - Retry budget exhausted, not retrying', ['clusterName' => $this->clusterName]);
+                break;
+            }
+            $this->recordAttempt();
+            $attempt++;
             $exception = null;
             reset($hostConfigs);
             $numRetriesLeft = count($hostConfigs) - 1;
@@ -861,6 +938,98 @@ class Client implements LoggerAwareInterface
             @socket_close($this->socket);
             $this->socket = null;
         }
+    }
+
+    /**
+     * Whether APCu-backed shared state (circuit breaker, retry budget) is usable in this environment.
+     *
+     * @suppress PhanUndeclaredConstant - suppresses ARE_GITHUB_ACTIONS_RUNNING
+     */
+    private function apcuAvailable(): bool
+    {
+        return (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING)
+            && function_exists('apcu_enabled') && apcu_enabled();
+    }
+
+    /**
+     * Returns false when the per-cluster circuit breaker is open, so the caller fails fast instead of
+     * attempting a request that is likely to block until it exhausts every host.
+     */
+    private function circuitBreakerAllowsRequest(): bool
+    {
+        if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
+            return true;
+        }
+        $state = apcu_fetch(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName);
+
+        return !is_array($state) || ($state['openUntil'] ?? 0) <= time();
+    }
+
+    /**
+     * Records a cluster-unreachable failure. Once failures reach the threshold, the breaker opens for the
+     * cooldown window and subsequent calls fail fast until a probe after cooldown succeeds.
+     */
+    private function recordCircuitFailure(): void
+    {
+        if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
+            return;
+        }
+        $key = self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName;
+        $state = apcu_fetch($key);
+        $failures = (is_array($state) ? ($state['failures'] ?? 0) : 0) + 1;
+        $ttl = $this->circuitBreakerCooldown + 60;
+        if ($failures >= $this->circuitBreakerThreshold) {
+            $this->logger->info('Bedrock\Client - Circuit breaker opened', ['clusterName' => $this->clusterName, 'cooldown' => $this->circuitBreakerCooldown]);
+            apcu_store($key, ['failures' => 0, 'openUntil' => time() + $this->circuitBreakerCooldown], $ttl);
+        } else {
+            apcu_store($key, ['failures' => $failures, 'openUntil' => 0], $ttl);
+        }
+    }
+
+    /**
+     * Clears the circuit breaker after a successful call so a recovered cluster resumes immediately.
+     */
+    private function recordCircuitSuccess(): void
+    {
+        if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
+            return;
+        }
+        apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName);
+    }
+
+    /**
+     * Counts one attempt (first try or retry) toward the current minute's box-wide retry-budget window.
+     */
+    private function recordAttempt(): void
+    {
+        if ($this->retryBudgetRatio <= 0 || !$this->apcuAvailable()) {
+            return;
+        }
+        $success = false;
+        apcu_inc(self::RETRY_BUDGET_CACHE_PREFIX.$this->clusterName.'-att-'.floor(time() / 60), 1, $success, 120);
+    }
+
+    /**
+     * Enforces a box-wide retry budget: retries are allowed only while they stay under retryBudgetRatio of
+     * total attempts this minute, capping retry amplification during an outage without throttling normal
+     * failover. Returns true when a retry is permitted.
+     */
+    private function consumeRetryBudget(): bool
+    {
+        if ($this->retryBudgetRatio <= 0 || !$this->apcuAvailable()) {
+            return true;
+        }
+        $minute = floor(time() / 60);
+        $attempts = apcu_fetch(self::RETRY_BUDGET_CACHE_PREFIX.$this->clusterName.'-att-'.$minute) ?: 0;
+        $success = false;
+        $retries = apcu_inc(self::RETRY_BUDGET_CACHE_PREFIX.$this->clusterName.'-ret-'.$minute, 1, $success, 120);
+
+        // Allow retries freely until there's a meaningful sample this minute; low traffic can't storm anyway.
+        if ($attempts < self::RETRY_BUDGET_MIN_SAMPLE) {
+            return true;
+        }
+
+        return ($retries / $attempts) <= $this->retryBudgetRatio;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -184,8 +184,8 @@ class Client implements LoggerAwareInterface
      *                      int|null             maxBlackListTimeout When a host fails, it will blacklist it and not try to reuse it for up to this amount of seconds.
      *                      int|null             commandPriority     The priority to send the commands with
      *                      string|null          logParam            Extra data to add to the bedrock logs
-     *                      int|null             circuitBreakerThreshold Cluster-unreachable failures before the breaker opens (0 disables)
-     *                      int|null             circuitBreakerCooldown  Seconds the breaker stays open once tripped
+     *                      int                  circuitBreakerThreshold Cluster-unreachable failures before the breaker opens (0 disables)
+     *                      int                  circuitBreakerCooldown  Seconds the breaker stays open once tripped
      *
      * @throws BedrockError
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -901,7 +901,7 @@ class Client implements LoggerAwareInterface
     }
 
     /**
-     * Whether APCu-backed shared state (circuit breaker, retry budget) is usable in this environment.
+     * Whether APCu-backed shared state (the circuit breaker) is usable in this environment.
      *
      * @suppress PhanUndeclaredConstant - suppresses ARE_GITHUB_ACTIONS_RUNNING
      */
@@ -953,8 +953,10 @@ class Client implements LoggerAwareInterface
         $incremented = false;
         $failures = apcu_inc(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails', 1, $incremented, $ttl);
         if ($failures >= $this->circuitBreakerThreshold) {
-            $this->logger->info('Bedrock\Client - Circuit breaker opened', ['clusterName' => $this->clusterName, 'cooldown' => $this->circuitBreakerCooldown]);
-            apcu_store($openKey, time() + $this->circuitBreakerCooldown, $ttl);
+            // apcu_add only succeeds for the first worker to cross the threshold, so the trip logs once.
+            if (apcu_add($openKey, time() + $this->circuitBreakerCooldown, $ttl)) {
+                $this->logger->info('Bedrock\Client - Circuit breaker opened', ['clusterName' => $this->clusterName, 'cooldown' => $this->circuitBreakerCooldown]);
+            }
         }
     }
 
@@ -966,8 +968,14 @@ class Client implements LoggerAwareInterface
         if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
             return;
         }
-        apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails');
-        apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open');
+        $failsKey = self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails';
+        $openKey = self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open';
+        // Only take the write lock when there is actually state to clear, so a successful call on a
+        // healthy cluster (the vast majority) does cheap reads and no writes.
+        if (apcu_fetch($failsKey) !== false || apcu_fetch($openKey) !== false) {
+            apcu_delete($failsKey);
+            apcu_delete($openKey);
+        }
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -352,9 +352,10 @@ class Client implements LoggerAwareInterface
 
     /**
      * Makes a call to Bedrock, guarded by a per-cluster circuit breaker: once the cluster has been
-     * repeatedly unreachable, calls fail fast instead of each tying up a worker until it exhausts every
-     * host. A ConnectionFailure (no usable response from any host) counts toward tripping the breaker;
-     * command-level BedrockErrors do not.
+     * repeatedly unreachable/unresponsive, calls fail fast instead of each tying up a worker until it
+     * exhausts every host. Any thrown BedrockError (connection failure, read timeout, empty/garbled
+     * response) counts toward tripping the breaker; command-level errors are returned, not thrown, so
+     * they never trip it.
      *
      * @param string $method  Request method
      * @param array  $headers Request headers (optional)
@@ -373,7 +374,7 @@ class Client implements LoggerAwareInterface
         }
         try {
             $response = $this->doCall($method, $headers, $body);
-        } catch (ConnectionFailure $e) {
+        } catch (BedrockError $e) {
             $this->recordCircuitFailure();
             throw $e;
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -944,29 +944,27 @@ class Client implements LoggerAwareInterface
         if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
             return true;
         }
-        $state = apcu_fetch(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName);
+        $openUntil = apcu_fetch(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open');
 
-        return !is_array($state) || ($state['openUntil'] ?? 0) <= time();
+        return $openUntil === false || $openUntil <= time();
     }
 
     /**
-     * Records a cluster-unreachable failure. Once failures reach the threshold, the breaker opens for the
-     * cooldown window and subsequent calls fail fast until a probe after cooldown succeeds.
+     * Records a cluster-unreachable failure. The failure count is an atomic APCu counter so concurrent
+     * workers can't lose increments; once it reaches the threshold the breaker opens for the cooldown
+     * window and subsequent calls fail fast until a probe after cooldown succeeds.
      */
     private function recordCircuitFailure(): void
     {
         if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
             return;
         }
-        $key = self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName;
-        $state = apcu_fetch($key);
-        $failures = (is_array($state) ? ($state['failures'] ?? 0) : 0) + 1;
         $ttl = $this->circuitBreakerCooldown + 60;
+        $incremented = false;
+        $failures = apcu_inc(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails', 1, $incremented, $ttl);
         if ($failures >= $this->circuitBreakerThreshold) {
             $this->logger->info('Bedrock\Client - Circuit breaker opened', ['clusterName' => $this->clusterName, 'cooldown' => $this->circuitBreakerCooldown]);
-            apcu_store($key, ['failures' => 0, 'openUntil' => time() + $this->circuitBreakerCooldown], $ttl);
-        } else {
-            apcu_store($key, ['failures' => $failures, 'openUntil' => 0], $ttl);
+            apcu_store(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open', time() + $this->circuitBreakerCooldown, $ttl);
         }
     }
 
@@ -978,7 +976,8 @@ class Client implements LoggerAwareInterface
         if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
             return;
         }
-        apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName);
+        apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails');
+        apcu_delete(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open');
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -926,9 +926,17 @@ class Client implements LoggerAwareInterface
     }
 
     /**
-     * Records a cluster-unreachable failure. The failure count is an atomic APCu counter so concurrent
-     * workers can't lose increments; once it reaches the threshold the breaker opens for the cooldown
-     * window and subsequent calls fail fast until a probe after cooldown succeeds.
+     * Records a cluster-unreachable failure.
+     *
+     * If the breaker is already tripped (the '-open' key exists — i.e. we're in the post-cooldown probe
+     * window), a single failure re-opens it immediately and refreshes that key, so a still-down cluster
+     * stays tripped for the whole outage without having to re-accumulate the threshold. Otherwise the
+     * breaker is closed and we count failures toward the threshold with an atomic apcu_inc (so concurrent
+     * workers can't lose increments).
+     *
+     * TTLs are cooldown + 60s: long enough that the '-open' key always outlives its cooldown window (so
+     * the breaker never closes early) and the '-fails' count survives a burst, but short enough to
+     * self-clean once traffic goes quiet.
      */
     private function recordCircuitFailure(): void
     {
@@ -936,11 +944,17 @@ class Client implements LoggerAwareInterface
             return;
         }
         $ttl = $this->circuitBreakerCooldown + 60;
+        $openKey = self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open';
+        if (apcu_fetch($openKey) !== false) {
+            apcu_store($openKey, time() + $this->circuitBreakerCooldown, $ttl);
+
+            return;
+        }
         $incremented = false;
         $failures = apcu_inc(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails', 1, $incremented, $ttl);
         if ($failures >= $this->circuitBreakerThreshold) {
             $this->logger->info('Bedrock\Client - Circuit breaker opened', ['clusterName' => $this->clusterName, 'cooldown' => $this->circuitBreakerCooldown]);
-            apcu_store(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open', time() + $this->circuitBreakerCooldown, $ttl);
+            apcu_store($openKey, time() + $this->circuitBreakerCooldown, $ttl);
         }
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -905,7 +905,7 @@ class Client implements LoggerAwareInterface
      *
      * @suppress PhanUndeclaredConstant - suppresses ARE_GITHUB_ACTIONS_RUNNING
      */
-    private function apcuAvailable(): bool
+    private function isApcuAvailable(): bool
     {
         return (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING)
             && function_exists('apcu_enabled') && apcu_enabled();
@@ -917,7 +917,7 @@ class Client implements LoggerAwareInterface
      */
     private function circuitBreakerAllowsRequest(): bool
     {
-        if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
+        if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return true;
         }
         $openUntil = apcu_fetch(self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-open');
@@ -940,7 +940,7 @@ class Client implements LoggerAwareInterface
      */
     private function recordCircuitFailure(): void
     {
-        if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
+        if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return;
         }
         $ttl = $this->circuitBreakerCooldown + 60;
@@ -965,7 +965,7 @@ class Client implements LoggerAwareInterface
      */
     private function recordCircuitSuccess(): void
     {
-        if ($this->circuitBreakerThreshold <= 0 || !$this->apcuAvailable()) {
+        if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return;
         }
         $failsKey = self::CIRCUIT_BREAKER_CACHE_PREFIX.$this->clusterName.'-fails';

--- a/src/Client.php
+++ b/src/Client.php
@@ -644,15 +644,13 @@ class Client implements LoggerAwareInterface
     /**
      * @param ?string $preferredHost If passed, it will prefer this host over any of the configured ones. This does not
      *                               ensure it will use that host, but it will try to use it if its not blacklisted.
-     *
-     * @suppress PhanUndeclaredConstant - suppresses ARE_GITHUB_ACTIONS_RUNNING
      */
     private function getPossibleHosts(?string $preferredHost)
     {
         // We get the host configs from the APC cache. Then, we check the configuration there with the passed
         // configuration and if it's outdated (ie: it has different hosts from the one in the config), we reset it. This
         // is so that we don't keep the old cache after changing the hosts or failover configuration.
-        if (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING) {
+        if ($this->isApcuAvailable()) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;
             $cachedHostConfigs = apcu_fetch($apcuKey) ?: [];
             $this->logger->debug('Bedrock\Client - APC fetch host configs', array_keys($cachedHostConfigs));
@@ -876,8 +874,6 @@ class Client implements LoggerAwareInterface
      * know it's down. The blacklist time is a random amount of time between 1 second and the maxBlackListTimeout
      * configuration.
      * We also close and clear the socket from the cache, so we don't reuse it.
-     *
-     * @suppress PhanUndeclaredConstant - suppresses ARE_GITHUB_ACTIONS_RUNNING
      */
     private function markHostAsFailed(string $host)
     {
@@ -885,7 +881,7 @@ class Client implements LoggerAwareInterface
             return;
         }
         $blacklistedUntil = time() + rand(1, $this->maxBlackListTimeout);
-        if (!defined('ARE_GITHUB_ACTIONS_RUNNING') || !ARE_GITHUB_ACTIONS_RUNNING) {
+        if ($this->isApcuAvailable()) {
             $apcuKey = self::APCU_CACHE_PREFIX.$this->clusterName;
             $hostConfigs = apcu_fetch($apcuKey);
             $hostConfigs[$host]['blacklistedUntil'] = $blacklistedUntil;


### PR DESCRIPTION
# Explanation of Change

Adds a circuit breaker to the client.

The way it works is we wrap the existing call method with the circuit breaker logic. If 10 requests fail, we fail requests immediately for the next 10 seconds and then check if they're working again. If they work, close the breaker and resume normal operation. If it fails, keep it open and wait another 10 seconds.

### Related Issues

Relates to https://github.com/Expensify/Expensify/issues/657702

It's an alternate way of solving the issue.

## Deployment

- [x] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly

## Tests

Claude wrote a test script for me. It 
* sends requests to auth in my dev enviroment and confirms they work
* sends requests to an invalid port where no bedrock is listening and confirms it trips a circuit breaker, but uses the same cluster name prefix to fake trip it
* sends requests to auth again and confirm the circuit breaker closed and they work

```
<?php
/**
 * Manual test for the Bedrock circuit breaker (Bedrock-PHP #258).
 *
 * Proves three behaviors in one run, and prints the underlying APCu breaker state after every call:
 *   1. HEALTHY   — normal traffic is unaffected (breaker stays closed; fails=none).
 *   2. DOWN      — failures make the fails counter climb to the threshold, the breaker opens, then
 *                  subsequent calls fail fast.
 *   3. RECOVERY  — after the cooldown a healthy probe succeeds and both APCu keys are cleared.
 *
 * It does NOT stop or mock Bedrock: healthy phases hit the real local Bedrock (8888); the "down"
 * phase just points the client at a dead port (connection refused).
 *
 * Run inside the Expensidev VM (APCu on for CLI; auto_prepend off so the app bootstrap doesn't load
 * the vendor Client before we load the branch one):
 *   php -d apc.enable_cli=1 -d auto_prepend_file= -d auto_append_file= /tmp/circuit-breaker-test.php
 *
 * /vagrant/Bedrock-PHP must be on the PR branch (jpersaud-bedrock-circuit-breaker).
 */

require '/vagrant/Web-Expensify/vendor/autoload.php'; // deps: PSR log, NullStats, exceptions
require '/vagrant/Bedrock-PHP/src/Client.php';        // load the breaker version of the client

use Expensify\Bedrock\Client;

const CLUSTER = 'cbmanualtest'; const THRESHOLD = 3; const COOLDOWN = 5;
const HEALTHY = 8888;   // real local Bedrock
const DEAD_PORT = 9997; // nothing listening -> connection refused
const CMD = 'Status';

if (!defined('Expensify\\Bedrock\\Client::CIRCUIT_BREAKER_CACHE_PREFIX')) { fwrite(STDERR, "ERROR: no breaker — is /vagrant/Bedrock-PHP on the PR branch?\n"); exit(1); }
if (!(function_exists('apcu_enabled') && apcu_enabled())) { fwrite(STDERR, "ERROR: APCu off for CLI — run with -d apc.enable_cli=1\n"); exit(1); }

$failsKey = Client::CIRCUIT_BREAKER_CACHE_PREFIX . CLUSTER . '-fails';
$openKey  = Client::CIRCUIT_BREAKER_CACHE_PREFIX . CLUSTER . '-open';
apcu_delete($failsKey); apcu_delete($openKey); // clean start

// Reads the live APCu breaker state so we can display it as proof.
$state = function () use ($failsKey, $openKey): string {
    $f = apcu_fetch($failsKey);
    $o = apcu_fetch($openKey);
    $fails = ($f === false) ? 'none' : (string) $f;
    if ($o === false) { $open = 'none'; }
    else { $left = $o - time(); $open = $left > 0 ? "OPEN({$left}s left)" : 'cooldown-elapsed'; }
    return sprintf('apcu[fails=%-4s open=%s]', $fails, $open);
};

$make = fn(int $port) => Client::getInstance([
    'clusterName' => CLUSTER, 'logger' => new \Psr\Log\NullLogger(), 'stats' => new \Expensify\Bedrock\Stats\NullStats(),
    'mainHostConfigs' => ['127.0.0.1' => ['blacklistedUntil' => 0, 'port' => $port]], 'failoverHostConfigs' => [],
    'connectionTimeout' => 0, 'connectionTimeoutMicroseconds' => 500000, 'readTimeout' => 3, 'readTimeoutMicroseconds' => 0,
    'bedrockTimeout' => 3, 'maxBlackListTimeout' => 1, 'writeConsistency' => 'ASYNC', 'commandPriority' => null, 'logParam' => null,
    'circuitBreakerThreshold' => THRESHOLD, 'circuitBreakerCooldown' => COOLDOWN,
]);
$call = function (Client $c): array {
    $t = microtime(true);
    try { $c->call(CMD); return ['OK', (microtime(true) - $t) * 1000, '']; }
    catch (\Throwable $e) {
        $ff = strpos($e->getMessage(), 'circuit breaker open') !== false;
        return [$ff ? 'FAIL-FAST' : 'FAIL', (microtime(true) - $t) * 1000, $ff ? 'circuit breaker open' : trim(substr($e->getMessage(), 0, 42))];
    }
};

printf("======================================================================\n");
printf(" Bedrock circuit-breaker test — %s\n cluster=%s  threshold=%d  cooldown=%ds  apcu=ON\n", date('Y-m-d H:i:s'), CLUSTER, THRESHOLD, COOLDOWN);
printf("======================================================================\n\n");
$pass = 0;

printf("PHASE 1 — HEALTHY (real Bedrock 127.0.0.1:%d)\n", HEALTHY);
$h = $make(HEALTHY); $ok = true;
for ($i = 1; $i <= 5; $i++) { [$r, $ms] = $call($h); $ok = $ok && $r === 'OK'; printf("      [%s] call %d: %-9s %6.1f ms   %s\n", date('H:i:s'), $i, $r, $ms, $state()); }
$ok = $ok && apcu_fetch($openKey) === false; $pass += $ok; printf("   => breaker CLOSED, all calls succeeded, no APCu state   [%s]\n\n", $ok ? 'PASS' : 'FAIL');

printf("PHASE 2 — CLUSTER DOWN (dead port 127.0.0.1:%d)\n", DEAD_PORT);
$d = $make(DEAD_PORT); $sawFF = false; $before = 0; $tripped = false;
for ($i = 1; $i <= 6; $i++) {
    [$r, $ms, $note] = $call($d);
    if ($r === 'FAIL-FAST') { $sawFF = true; $tripped = true; } elseif (!$tripped) { $before++; }
    printf("      [%s] call %d: %-9s %6.1f ms  (%-22s) %s%s\n", date('H:i:s'), $i, $r, $ms, $note, $state(), $r === 'FAIL-FAST' ? '  <-- instant' : '');
}
$ok = $sawFF && $before === THRESHOLD && (int) apcu_fetch($failsKey) >= THRESHOLD; $pass += $ok;
printf("   => fails climbed to %d, breaker OPENED, then failed fast   [%s]\n\n", $before, $ok ? 'PASS' : 'FAIL');

printf("PHASE 3 — RECOVERY (wait %ds past cooldown, then real Bedrock)\n", COOLDOWN + 1);
printf("      [%s] sleeping %ds...   %s\n", date('H:i:s'), COOLDOWN + 1, $state());
sleep(COOLDOWN + 1);
$rc = $make(HEALTHY); $ok = true;
for ($i = 1; $i <= 3; $i++) { [$r, $ms] = $call($rc); $ok = $ok && $r === 'OK'; printf("      [%s] call %d: %-9s %6.1f ms   %s%s\n", date('H:i:s'), $i, $r, $ms, $state(), $i === 1 ? '  <-- probe OK, state cleared' : ''); }
$ok = $ok && apcu_fetch($failsKey) === false && apcu_fetch($openKey) === false; $pass += $ok;
printf("   => probe succeeded, both APCu keys cleared, service resumed   [%s]\n\n", $ok ? 'PASS' : 'FAIL');

printf("======================================================================\n RESULT: %d/3 phases PASS — circuit breaker %s\n======================================================================\n", $pass, $pass === 3 ? 'works as expected' : 'FAILED');
exit($pass === 3 ? 0 : 1);
```

```
expensidev-2404->/vagrant/Bedrock-PHP (jpersaud-bedrock-circuit-breaker) > php -d apc.enable_cli=1 -d auto_prepend_file= -d auto_append_file= /tmp/circuit-breaker-test.php
======================================================================
 Bedrock circuit-breaker test — 2026-07-13 17:34:50
 cluster=cbmanualtest  threshold=3  cooldown=5s  apcu=ON
======================================================================

PHASE 1 — HEALTHY (real Bedrock 127.0.0.1:8888)
      [17:34:50] call 1: OK           0.5 ms   apcu[fails=none open=none]
      [17:34:50] call 2: OK           0.3 ms   apcu[fails=none open=none]
      [17:34:50] call 3: OK           0.2 ms   apcu[fails=none open=none]
      [17:34:50] call 4: OK           0.2 ms   apcu[fails=none open=none]
      [17:34:50] call 5: OK           0.2 ms   apcu[fails=none open=none]
   => breaker CLOSED, all calls succeeded, no APCu state   [PASS]

PHASE 2 — CLUSTER DOWN (dead port 127.0.0.1:9997)
      [17:34:50] call 1: FAIL         1.0 ms  (Failed to send request to bedrock host 127) apcu[fails=1    open=none]
      [17:34:50] call 2: FAIL         0.1 ms  (Failed to send request to bedrock host 127) apcu[fails=2    open=none]
      [17:34:50] call 3: FAIL         0.0 ms  (Failed to send request to bedrock host 127) apcu[fails=3    open=OPEN(5s left)]
      [17:34:50] call 4: FAIL-FAST    0.0 ms  (circuit breaker open  ) apcu[fails=3    open=OPEN(5s left)]  <-- instant
      [17:34:50] call 5: FAIL-FAST    0.0 ms  (circuit breaker open  ) apcu[fails=3    open=OPEN(5s left)]  <-- instant
      [17:34:50] call 6: FAIL-FAST    0.0 ms  (circuit breaker open  ) apcu[fails=3    open=OPEN(5s left)]  <-- instant
   => fails climbed to 3, breaker OPENED, then failed fast   [PASS]

PHASE 3 — RECOVERY (wait 6s past cooldown, then real Bedrock)
      [17:34:50] sleeping 6s...   apcu[fails=3    open=OPEN(5s left)]
      [17:34:56] call 1: OK           1.3 ms   apcu[fails=none open=none]  <-- probe OK, state cleared
      [17:34:56] call 2: OK           0.8 ms   apcu[fails=none open=none]
      [17:34:56] call 3: OK           1.1 ms   apcu[fails=none open=none]
   => probe succeeded, both APCu keys cleared, service resumed   [PASS]

======================================================================
 RESULT: 3/3 phases PASS — circuit breaker works as expected
======================================================================
```

