### PR TITLE
Log circuit breaker trip at warning level for logwatcher visibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.3",
+    "version": "2.3.4",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -948,7 +948,7 @@ class Client implements LoggerAwareInterface
         if ($failures >= $this->circuitBreakerThreshold) {
             // apcu_add only succeeds for the first worker to cross the threshold, so the trip logs once.
             if (apcu_add($openKey, time() + $this->circuitBreakerCooldown, $ttl)) {
-                $this->logger->info('Bedrock\Client - Circuit breaker opened', ['clusterName' => $this->clusterName, 'cooldown' => $this->circuitBreakerCooldown]);
+                $this->logger->warning('Bedrock\Client - Circuit breaker opened', ['clusterName' => $this->clusterName, 'cooldown' => $this->circuitBreakerCooldown]);
             }
         }
     }


### PR DESCRIPTION
# Explanation of Change

Promotes the once-per-trip "Circuit breaker opened" log from `info` to `warning` so it surfaces in logwatcher when a cluster's breaker trips.

### Related Issues

For https://github.com/Expensify/Bedrock-PHP/pull/258

## Deployment

- [x] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
