### PR TITLE
[WIP] Add per-type AIMD load handling to BedrockWorkerManager

### DIFF
--- a/.github/workflows/bedrock-php.yml
+++ b/.github/workflows/bedrock-php.yml
@@ -66,3 +66,30 @@ jobs:
 
     - name: Test for Style
       run: "php ./ci/style.php"
+  PHP_Unit:
+    name: PHPUnit
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+    - name: checkout
+      # v4.1.0
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      with:
+        # Set fetch-depth to 100 so that we can compare HEAD with a good chunk of git log history
+        fetch-depth: 100
+
+    - name: Install PHP and Libraries
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+      with:
+        tools: composer:v2.7.1
+        php-version: 8.3.31
+        coverage: none
+      env:
+        GITHUB_TOKEN: ${{ secrets.CODE_EXPENSIFY_TOKEN }}
+        fail-fast: true
+
+    - name: Setup Composer Cache
+      uses: ./.github/actions/composite/setup-composer-cache
+
+    - name: Run PHPUnit tests
+      run: "vendor/bin/phpunit"

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -2,6 +2,12 @@
 
 declare(strict_types=1);
 
+use Expensify\Bedrock\Aimd\AimdConfig;
+use Expensify\Bedrock\Aimd\AimdController;
+use Expensify\Bedrock\Aimd\AimdIntervalStats;
+use Expensify\Bedrock\Aimd\PerTypeAimdConfig;
+use Expensify\Bedrock\Aimd\PerTypeAimdController;
+use Expensify\Bedrock\Aimd\PerTypeIntervalStats;
 use Expensify\Bedrock\Client;
 use Expensify\Bedrock\Exceptions\BedrockError;
 use Expensify\Bedrock\Exceptions\Jobs\DoesNotExist;
@@ -39,7 +45,8 @@ $options = getopt('', ['maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 
     'versionWatchFile::', 'writeConsistency::', 'enableLoadHandler', 'minSafeJobs::', 'maxJobsInSingleRun::',
     'maxSafeTime::', 'localJobsDBPath::', 'debugThrottle', 'backoffThreshold::',
     'intervalDurationSeconds::', 'doubleBackoffPreventionIntervalFraction::', 'multiplicativeDecreaseFraction::',
-    'jobsToAddPerSecond::', 'profileChangeThreshold::', ]);
+    'jobsToAddPerSecond::', 'profileChangeThreshold::', 'enablePerTypeAimd',
+    'criticalTypeFloors::', 'maxSafeTimeOverrides::', ]);
 
 $workerPath = $options['workerPath'] ?? null;
 if (!$workerPath) {
@@ -57,6 +64,17 @@ $maxJobsForSingleRun = intval($options['maxJobsInSingleRun'] ?? 10);
 $maxSafeTime = intval($options['maxSafeTime'] ?? 0); // The maximum job time before we start paying attention
 $debugThrottle = isset($options['debugThrottle']); // Set to true to maintain a debug history
 $enableLoadHandler = isset($options['enableLoadHandler']); // Enables the AIMD load handler
+
+// Enables the per-type AIMD load handler (tracks a target per job type) instead of the scalar one.
+// Requires --enableLoadHandler. Flag-gated so it can be rolled out to a subset of hosts.
+$enablePerTypeAimd = isset($options['enablePerTypeAimd']);
+
+// Per-type AIMD overrides, supplied as JSON so app-specific job names stay out of this generic
+// library. --criticalTypeFloors maps a bare job name to a guaranteed floor (e.g. {"SendValidateCode":10});
+// --maxSafeTimeOverrides maps a bare job name to a per-type latency threshold in seconds (e.g.
+// {"SmartScan":180}).
+$criticalTypeFloors = json_decode($options['criticalTypeFloors'] ?? '{}', true) ?: [];
+$maxSafeTimeOverrides = json_decode($options['maxSafeTimeOverrides'] ?? '{}', true) ?: [];
 
 // The fraction of run time the current batch of jobs needs to be in relation to the previous batch to cause us to
 // back off our target number of jobs.
@@ -77,13 +95,6 @@ $jobsToAddPerSecond = floatval($options['jobsToAddPerSecond'] ?? 1.0);
 
 $profileChangeThreshold = floatval($options['profileChangeThreshold'] ?? 0.25);
 
-// Internal state variables for determining the number of jobs to run at one time.
-// $target is the number of jobs that we think we can safely run at one time. It defaults to the number of jobs we've
-// decided is always safe, and is continually adjusted by `getNumberOfJobsToQueue`.
-$target = $minSafeJobs;
-$lastRun = microtime(true);
-$lastBackoff = 0;
-
 // This is the name of a particular job if it made up over 50% of the jobs previously returned. Its purpose is to
 // detect when we switch job types so that we can react appropriately.
 $lastJobProfile = 'none';
@@ -94,6 +105,41 @@ $bedrock = Client::getInstance();
 $logger = $bedrock->getLogger();
 $logger->info('Starting BedrockWorkerManager', ['maxIterations' => $maxIterations]);
 $stats = $bedrock->getStats();
+
+// The AIMD load handler. Holds the target job count and adjusts it each loop based on how job
+// timings are trending. getNumberOfJobsToQueue() gathers the timing data and delegates the
+// decision to this controller. Per-type AIMD is flag-gated so it can be rolled out gradually; when
+// off we use the historical scalar controller.
+if ($enablePerTypeAimd) {
+    $activeAimd = new PerTypeAimdController(
+        new PerTypeAimdConfig(
+            backoffThreshold: $backoffThreshold,
+            doubleBackoffPreventionIntervalFraction: $doubleBackoffPreventionIntervalFraction,
+            intervalDurationSeconds: $intervalDurationSeconds,
+            jobsToAddPerSecond: $jobsToAddPerSecond,
+            multiplicativeDecreaseFraction: $multiplicativeDecreaseFraction,
+            maxSafeTime: $maxSafeTime > 0 ? (float) $maxSafeTime : 30.0,
+            defaultTypeFloor: 1,
+            criticalTypeFloors: $criticalTypeFloors,
+            maxSafeTimeOverrides: $maxSafeTimeOverrides,
+        ),
+        microtime(true),
+        $logger,
+    );
+} else {
+    $activeAimd = new AimdController(
+        new AimdConfig(
+            backoffThreshold: $backoffThreshold,
+            doubleBackoffPreventionIntervalFraction: $doubleBackoffPreventionIntervalFraction,
+            intervalDurationSeconds: $intervalDurationSeconds,
+            jobsToAddPerSecond: $jobsToAddPerSecond,
+            minSafeJobs: $minSafeJobs,
+            multiplicativeDecreaseFraction: $multiplicativeDecreaseFraction,
+        ),
+        microtime(true),
+        $logger,
+    );
+}
 
 // Set up the database for the AIMD load handler.
 $localDB = new LocalDB($pathToDB, $logger, $stats);
@@ -173,12 +219,12 @@ try {
             } elseif ($jobsToQueue >= 3) {
                 // We ensure we ask minimum 3 jobs per GetJobs call, to avoid running tons of GetJobs calls back to back
                 // to return just 1 job
-                $logger->info('[AIMD] Safe to start a new job, checking for more work', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
+                $logger->info('[AIMD] Safe to start a new job, checking for more work', ['jobsToQueue' => $jobsToQueue, 'target' => $activeAimd->getTarget(), 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 $stats->counter('bedrockWorkerManager.currentJobsToQueue', $jobsToQueue);
-                $stats->counter('bedrockWorkerManager.targetJobsToQueue', (int) $target);
+                $stats->counter('bedrockWorkerManager.targetJobsToQueue', (int) $activeAimd->getTarget());
                 break;
             } else {
-                $logger->info('[AIMD] Not enough jobs to queue, waiting 0.5s and trying again.', ['jobsToQueue' => $jobsToQueue, 'target' => $target, 'load' => $load, 'MAX_LOAD' => $maxLoad]);
+                $logger->info('[AIMD] Not enough jobs to queue, waiting 0.5s and trying again.', ['jobsToQueue' => $jobsToQueue, 'target' => $activeAimd->getTarget(), 'load' => $load, 'MAX_LOAD' => $maxLoad]);
                 $localDB->write('DELETE FROM localJobs WHERE started < '.(microtime(true) - 60 * 60).' AND ended IS NULL;');
                 $isFirstTry = false;
                 usleep(500000);
@@ -522,19 +568,7 @@ $logger->info('Stopped BedrockWorkerManager, will not wait for children');
  */
 function getNumberOfJobsToQueue(): int
 {
-    global $backoffThreshold,
-    $doubleBackoffPreventionIntervalFraction,
-    $enableLoadHandler,
-    $intervalDurationSeconds,
-    $jobsToAddPerSecond,
-    $lastBackoff,
-    $lastRun,
-    $localDB,
-    $logger,
-    $maxJobsForSingleRun,
-    $minSafeJobs,
-    $multiplicativeDecreaseFraction,
-    $target;
+    global $activeAimd, $enableLoadHandler, $enablePerTypeAimd, $intervalDurationSeconds, $localDB, $logger, $maxJobsForSingleRun;
 
     // Allow for disabling of the load handler.
     if (!$enableLoadHandler) {
@@ -543,95 +577,46 @@ function getNumberOfJobsToQueue(): int
         return $maxJobsForSingleRun;
     }
     $now = microtime(true);
-
-    // Following line is only for testing.
-    // $secondElapsed = (intval($now) === intval($lastRun)) ? 0 : intval($now);
-
-    // Get timing info for the last two intervals.
-    $timeSinceLastRun = $now - $lastRun;
-    $lastRun = $now;
     $oneIntervalAgo = $now - $intervalDurationSeconds;
     $twoIntervalsAgo = $oneIntervalAgo - $intervalDurationSeconds;
 
-    // Look up how many jobs are currently in progress.
-    $numActive = intval($localDB->read('SELECT COUNT(*) FROM localJobs WHERE ended IS NULL;')[0]);
+    // Per-type AIMD needs per-type timing, so it reads the same windows grouped by jobName and lets
+    // the controller decide one target per type.
+    if ($enablePerTypeAimd && $activeAimd instanceof PerTypeAimdController) {
+        $activeRows = $localDB->readAll('SELECT jobName, COUNT(*) FROM localJobs WHERE ended IS NULL GROUP BY jobName;');
+        $lastRows = $localDB->readAll('SELECT jobName, COUNT(*), AVG(ended - started) FROM localJobs WHERE ended IS NOT NULL AND ended > '.$oneIntervalAgo.' GROUP BY jobName;');
+        $previousRows = $localDB->readAll('SELECT jobName, COUNT(*), AVG(ended - started) FROM localJobs WHERE ended IS NOT NULL AND ended > '.$twoIntervalsAgo.' AND ended < '.$oneIntervalAgo.' GROUP BY jobName;');
 
-    // Look up how many jobs we've finished recently.
-    $lastIntervalData = $localDB->read('SELECT COUNT(*), AVG(ended - started) FROM localJobs WHERE ended IS NOT NULL AND ended > '.$oneIntervalAgo.';');
-    $lastIntervalCount = $lastIntervalData[0];
-    $lastIntervalAverage = floatval($lastIntervalData[1]);
+        // Delete old stuff.
+        $localDB->write('DELETE FROM localJobs WHERE ended IS NOT NULL AND ended < '.$twoIntervalsAgo.';');
 
-    $previousIntervalData = $localDB->read('SELECT COUNT(*), AVG(ended - started) FROM localJobs WHERE ended IS NOT NULL AND ended > '.$twoIntervalsAgo.' AND ended < '.$oneIntervalAgo.';');
-    $previousIntervalCount = $previousIntervalData[0];
-    $previousIntervalAverage = floatval($previousIntervalData[1]);
-
-    // Following block is only for testing.
-    // if ($secondElapsed) {
-    //     echo "$secondElapsed, $numActive, $target, $lastIntervalAverage\n";
-    // }
-
-    // Delete old stuff.
-    $localDB->write('DELETE FROM localJobs WHERE ended IS NOT NULL AND ended < '.$twoIntervalsAgo.';');
-
-    // If we don't have enough data, we'll return a value based on the current target and active job count.
-    if ($lastIntervalCount === 0) {
-        $logger->info('[AIMD] No jobs finished this interval, returning default value.', ['minSafeJobs' => $minSafeJobs, 'returnValue' => max($target - $numActive, 0)]);
-
-        return intval(max($target - $numActive, 0));
-    } elseif ($previousIntervalCount === 0) {
-        $logger->info('[AIMD] No jobs finished previous interval, returning default value.', ['minSafeJobs' => $minSafeJobs, 'returnValue' => max($target - $numActive, 0)]);
-
-        return intval(max($target - $numActive, 0));
+        return $activeAimd->decide(PerTypeIntervalStats::fromGroupedRows($activeRows, $lastRows, $previousRows), $now);
     }
 
-    // Update our target. If the last interval average run time exceeds the previous one by too much, back off.
-    // Options:
-    // 1. Make intervalDurationSeconds longer for more data to average.
-    // 2. Make backoffThreshold higher (this seems riskier)
-    // 3. Back off by less (increase multiplicativeDecreaseFraction closer to 1).
-    //
-    // Possibly helpful ideas:
-    // Log the count and type of jobs used to calculate lastIntervalData and previousIntervalData.
-    // Also log the times for each type of job.
-    //
-    // Just knowing the count of completed jobs in the previous intervals is interesting. If it's a very small number
-    // of jobs, a high degree of variability is expected.
-    if ($lastIntervalAverage > ($previousIntervalAverage * $backoffThreshold)) {
-        // Skip backoff if we've done so too recently in the past. (within 10 seconds by default)
-        if ($lastBackoff < $now - ($intervalDurationSeconds * $doubleBackoffPreventionIntervalFraction)) {
-            $target = max($target * $multiplicativeDecreaseFraction, $minSafeJobs);
-            $lastBackoff = $now;
-            $logger->info('[AIMD] Backing off jobs target.', [
-                'target' => $target,
-                'lastIntervalAverage' => $lastIntervalAverage,
-                'previousIntervalAverage' => $previousIntervalAverage,
-                'backoffThreshold' => $backoffThreshold,
-            ]);
-        }
-    } else {
-        // Otherwise, slowly ramp up. Increase by $jobsToAddPerSecond every second, except don't increase past 2x the
-        // number of currently running jobs.
-        if (($target + $timeSinceLastRun * $jobsToAddPerSecond) < $numActive * 2) {
-            // Ok, we're running at least half this many jobs, we can increment.
-            $target += $timeSinceLastRun * $jobsToAddPerSecond;
-        }
-        $logger->info('[AIMD] Congestion Avoidance, incrementing target', ['target' => $target]);
+    // Scalar AIMD: aggregate counts across all job types.
+    if ($activeAimd instanceof AimdController) {
+        $numActive = intval($localDB->read('SELECT COUNT(*) FROM localJobs WHERE ended IS NULL;')[0]);
+        $lastIntervalData = $localDB->read('SELECT COUNT(*), AVG(ended - started) FROM localJobs WHERE ended IS NOT NULL AND ended > '.$oneIntervalAgo.';');
+        $previousIntervalData = $localDB->read('SELECT COUNT(*), AVG(ended - started) FROM localJobs WHERE ended IS NOT NULL AND ended > '.$twoIntervalsAgo.' AND ended < '.$oneIntervalAgo.';');
+
+        // Delete old stuff.
+        $localDB->write('DELETE FROM localJobs WHERE ended IS NOT NULL AND ended < '.$twoIntervalsAgo.';');
+
+        // Hand the timing snapshot to the AIMD controller, which updates the target and returns how
+        // many jobs it is safe to queue now.
+        return $activeAimd->decide(
+            new AimdIntervalStats(
+                $numActive,
+                intval($lastIntervalData[0]),
+                floatval($lastIntervalData[1]),
+                intval($previousIntervalData[0]),
+                floatval($previousIntervalData[1]),
+            ),
+            $now,
+        );
     }
 
-    // Now we know how many jobs we want to be running, and how many are running, so we can return the difference.
-    $numJobsToRun = intval(max($target - $numActive, 0));
-    $logger->info('[AIMD] Found number of jobs to run.', [
-        'numJobsToRun' => $numJobsToRun,
-        'target' => $target,
-        'numActive' => $numActive,
-        'lastIntervalAverage' => $lastIntervalAverage,
-        'previousIntervalAverage' => $previousIntervalAverage,
-        'lastIntervalCount' => $lastIntervalCount,
-        'previousIntervalCount' => $previousIntervalCount,
-        'timeSinceLastRun' => $timeSinceLastRun,
-    ]);
-
-    return $numJobsToRun;
+    return $maxJobsForSingleRun;
 }
 
 /**

--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -120,6 +120,7 @@ if ($enablePerTypeAimd) {
             multiplicativeDecreaseFraction: $multiplicativeDecreaseFraction,
             maxSafeTime: $maxSafeTime > 0 ? (float) $maxSafeTime : 30.0,
             defaultTypeFloor: 1,
+            minSafeJobs: $minSafeJobs,
             criticalTypeFloors: $criticalTypeFloors,
             maxSafeTimeOverrides: $maxSafeTimeOverrides,
         ),

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64.0",
-        "phan/phan": "^5.4.5"
+        "phan/phan": "^5.4.5",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {
@@ -30,8 +31,12 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Expensify\\Bedrock\\CI\\": "ci/src"
+            "Expensify\\Bedrock\\CI\\": "ci/src",
+            "Expensify\\Bedrock\\Tests\\": "tests"
         }
+    },
+    "scripts": {
+        "test": "phpunit"
     },
     "bin": [
         "bin/BedrockWorkerManager.php"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64.0",
         "phan/phan": "^5.4.5",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68e64847144def50bb1bb4a55f9dd659",
+    "content-hash": "c28292f848555d809975f82daed55f10",
     "packages": [
         {
             "name": "psr/log",
@@ -699,6 +699,66 @@
             "time": "2022-10-05T17:30:19+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
             "name": "netresearch/jsonmapper",
             "version": "v4.5.0",
             "source": {
@@ -748,6 +808,63 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
             },
             "time": "2024-09-08T10:13:13+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phan/phan",
@@ -828,6 +945,124 @@
                 "source": "https://github.com/phan/phan/tree/5.4.5"
             },
             "time": "2024-08-13T21:41:35+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1050,6 +1285,441 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
             },
             "time": "2025-02-19T13:28:12+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "12.5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "186dab580576598076de6818596d12b61801880e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.28"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.5.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-01T13:24:19+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T14:04:18+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^12.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:58+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:16+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:38+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "12.5.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "c02591dd7840ed124a98d7770753329ad28e9f8f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c02591dd7840ed124a98d7770753329ad28e9f8f",
+                "reference": "c02591dd7840ed124a98d7770753329ad28e9f8f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.7",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.1",
+                "sebastian/comparator": "^7.1.8",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/exporter": "^7.0.3",
+                "sebastian/global-state": "^8.0.3",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.4",
+                "sebastian/version": "^6.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.32"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-25T06:54:13+00:00"
         },
         {
             "name": "psr/container",
@@ -1747,6 +2417,225 @@
             "time": "2024-08-27T11:23:05+00:00"
         },
         {
+            "name": "sebastian/cli-parser",
+            "version": "4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-17T05:29:34+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "7.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "7c65c1e79836812819705b473a90c12399542485"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
+                "reference": "7c65c1e79836812819705b473a90c12399542485",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-21T04:45:25+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:25+00:00"
+        },
+        {
             "name": "sebastian/diff",
             "version": "7.0.0",
             "source": {
@@ -1812,6 +2701,681 @@
                 }
             ],
             "time": "2025-02-07T04:55:46+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.26"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:40:20+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "7.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T04:37:17+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "8.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0.1"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^12.5.28"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-01T15:10:33+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-19T16:22:07+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:57:48+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:17+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:44:59+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "6.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T06:45:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/console",
@@ -3095,6 +4659,56 @@
             "time": "2025-04-20T20:18:16+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
             "name": "tysonandre/var_representation_polyfill",
             "version": "0.1.3",
             "source": {
@@ -3217,10 +4831,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnNotice="true">
+    <testsuites>
+        <testsuite name="Bedrock-PHP">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Aimd/AimdConfig.php
+++ b/src/Aimd/AimdConfig.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Aimd;
+
+/**
+ * Immutable tuning parameters for the AIMD load handler.
+ *
+ * These mirror the CLI options parsed in bin/BedrockWorkerManager.php; the defaults here match the
+ * defaults declared there so constructing an AimdConfig with no arguments behaves identically to
+ * the historical scalar implementation.
+ */
+final class AimdConfig
+{
+    public function __construct(
+        // The fraction slower the current batch of jobs must be, relative to the previous batch, to
+        // cause us to back off the target number of jobs.
+        public readonly float $backoffThreshold = 1.1,
+        // The fraction of an interval during which a second backoff is suppressed, so we step down
+        // once rather than repeatedly on successive loops.
+        public readonly float $doubleBackoffPreventionIntervalFraction = 1.0,
+        // The length of time (seconds) used to average the speed of recently finished jobs.
+        public readonly float $intervalDurationSeconds = 10.0,
+        // How many jobs we try to add to the target per second while ramping up.
+        public readonly float $jobsToAddPerSecond = 1.0,
+        // The floor of the number of jobs we target running simultaneously.
+        public readonly int $minSafeJobs = 10,
+        // On backoff we multiply the target by this value. Between 0 and 1.
+        public readonly float $multiplicativeDecreaseFraction = 0.8,
+    ) {
+    }
+}

--- a/src/Aimd/AimdController.php
+++ b/src/Aimd/AimdController.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Aimd;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * AIMD (Additive Increase / Multiplicative Decrease) controller for BedrockWorkerManager.
+ *
+ * Holds the running target (the number of jobs we believe we can safely run at once) and adjusts it
+ * once per control loop: back off multiplicatively when jobs are getting slower, otherwise ramp up
+ * additively. All database access and clock reads happen in the caller and are passed in via
+ * AimdIntervalStats and $now, so this class is pure and unit testable.
+ *
+ * This is a behavior-preserving extraction of the logic that previously lived inline in
+ * getNumberOfJobsToQueue() in bin/BedrockWorkerManager.php.
+ */
+final class AimdController implements AimdTargetReporter
+{
+    /** The number of jobs we currently believe we can safely run at once. */
+    private float $target;
+
+    /** The time decide() last ran, used to scale the additive increase. */
+    private float $lastRun;
+
+    /** The time we last backed off, used to suppress a second backoff within one interval. */
+    private float $lastBackoff = 0.0;
+
+    public function __construct(
+        private readonly AimdConfig $config,
+        float $now,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+        $this->target = $config->minSafeJobs;
+        $this->lastRun = $now;
+    }
+
+    /**
+     * The current target. Exposed so the caller can emit it as a stat/log line.
+     */
+    public function getTarget(): float
+    {
+        return $this->target;
+    }
+
+    /**
+     * Given this loop's job-timing snapshot and the current time, update the target and return how
+     * many additional jobs it is safe to queue right now.
+     */
+    public function decide(AimdIntervalStats $stats, float $now): int
+    {
+        $timeSinceLastRun = $now - $this->lastRun;
+        $this->lastRun = $now;
+
+        // If we don't have enough data (this interval or the previous one had no finished jobs) we
+        // can't compare speeds, so hold the target and return the current headroom.
+        if ($stats->lastIntervalCount === 0) {
+            $this->logger?->info('[AIMD] No jobs finished this interval, returning default value.', ['minSafeJobs' => $this->config->minSafeJobs, 'returnValue' => max($this->target - $stats->numActive, 0)]);
+
+            return $this->jobsToRun($stats);
+        }
+        if ($stats->previousIntervalCount === 0) {
+            $this->logger?->info('[AIMD] No jobs finished previous interval, returning default value.', ['minSafeJobs' => $this->config->minSafeJobs, 'returnValue' => max($this->target - $stats->numActive, 0)]);
+
+            return $this->jobsToRun($stats);
+        }
+
+        // If the last interval's average run time exceeds the previous one by too much, back off.
+        if ($stats->lastIntervalAverage > ($stats->previousIntervalAverage * $this->config->backoffThreshold)) {
+            // Skip the backoff if we did so too recently (within one interval by default), so we
+            // step down once rather than to the floor on each successive loop.
+            if ($this->lastBackoff < $now - ($this->config->intervalDurationSeconds * $this->config->doubleBackoffPreventionIntervalFraction)) {
+                $this->target = max($this->target * $this->config->multiplicativeDecreaseFraction, $this->config->minSafeJobs);
+                $this->lastBackoff = $now;
+                $this->logger?->info('[AIMD] Backing off jobs target.', [
+                    'target' => $this->target,
+                    'lastIntervalAverage' => $stats->lastIntervalAverage,
+                    'previousIntervalAverage' => $stats->previousIntervalAverage,
+                    'backoffThreshold' => $this->config->backoffThreshold,
+                ]);
+            }
+        } else {
+            // Otherwise slowly ramp up, but don't increase past 2x the number of currently running
+            // jobs.
+            if (($this->target + $timeSinceLastRun * $this->config->jobsToAddPerSecond) < $stats->numActive * 2) {
+                $this->target += $timeSinceLastRun * $this->config->jobsToAddPerSecond;
+            }
+            $this->logger?->info('[AIMD] Congestion Avoidance, incrementing target', ['target' => $this->target]);
+        }
+
+        $numJobsToRun = $this->jobsToRun($stats);
+        $this->logger?->info('[AIMD] Found number of jobs to run.', [
+            'numJobsToRun' => $numJobsToRun,
+            'target' => $this->target,
+            'numActive' => $stats->numActive,
+            'lastIntervalAverage' => $stats->lastIntervalAverage,
+            'previousIntervalAverage' => $stats->previousIntervalAverage,
+            'lastIntervalCount' => $stats->lastIntervalCount,
+            'previousIntervalCount' => $stats->previousIntervalCount,
+            'timeSinceLastRun' => $timeSinceLastRun,
+        ]);
+
+        return $numJobsToRun;
+    }
+
+    /**
+     * The number of jobs to queue given the current target: the difference between the target and
+     * what's already running, floored at zero.
+     */
+    private function jobsToRun(AimdIntervalStats $stats): int
+    {
+        return intval(max($this->target - $stats->numActive, 0));
+    }
+}

--- a/src/Aimd/AimdIntervalStats.php
+++ b/src/Aimd/AimdIntervalStats.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Aimd;
+
+/**
+ * A snapshot of local job timing for a single control loop.
+ *
+ * The caller reads these numbers from the localJobs database once per loop and hands them to
+ * AimdController::decide(), which keeps the control logic free of any database or clock access so
+ * it can be unit tested.
+ */
+final class AimdIntervalStats
+{
+    public function __construct(
+        // Jobs currently running (ended IS NULL).
+        public readonly int $numActive,
+        // Count and average duration of jobs that finished in the most recent interval.
+        public readonly int $lastIntervalCount,
+        public readonly float $lastIntervalAverage,
+        // Count and average duration of jobs that finished in the interval before that.
+        public readonly int $previousIntervalCount,
+        public readonly float $previousIntervalAverage,
+    ) {
+    }
+}

--- a/src/Aimd/AimdTargetReporter.php
+++ b/src/Aimd/AimdTargetReporter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Aimd;
+
+/**
+ * Implemented by both the scalar (AimdController) and per-type (PerTypeAimdController) load
+ * handlers so BedrockWorkerManager can report the current target as a stat/log line without caring
+ * which implementation is active.
+ */
+interface AimdTargetReporter
+{
+    /**
+     * The current target job count. For the per-type handler this is the sum across all types.
+     */
+    public function getTarget(): float;
+}

--- a/src/Aimd/PerTypeAimdConfig.php
+++ b/src/Aimd/PerTypeAimdConfig.php
@@ -36,6 +36,10 @@ final class PerTypeAimdConfig
         public readonly float $maxSafeTime = 30.0,
         // Default per-type floor. Kept low so many job types don't sum to a huge fleet minimum.
         public readonly int $defaultTypeFloor = 1,
+        // Global baseline: the aggregate fetch never drops below (minSafeJobs - total active jobs),
+        // so BWM keeps discovering work (including brand-new job types not yet in the local DB) and
+        // never wedges on a fresh/idle localJobs DB. Mirrors the scalar handler's minSafeJobs floor.
+        public readonly int $minSafeJobs = 10,
         public readonly array $criticalTypeFloors = [],
         public readonly array $maxSafeTimeOverrides = [],
         // Safety ceiling on how many jobs a single GetJobs call may request.

--- a/src/Aimd/PerTypeAimdConfig.php
+++ b/src/Aimd/PerTypeAimdConfig.php
@@ -16,7 +16,7 @@ final class PerTypeAimdConfig
 {
     /**
      * @param array<string, int>   $criticalTypeFloors   bare job name => guaranteed minimum target
-     * @param array<string, float> $maxSafeTimeOverrides  bare job name => per-type maxSafeTime (seconds)
+     * @param array<string, float> $maxSafeTimeOverrides bare job name => per-type maxSafeTime (seconds)
      */
     public function __construct(
         // Fraction slower this interval must be vs the previous one to back a type off.

--- a/src/Aimd/PerTypeAimdConfig.php
+++ b/src/Aimd/PerTypeAimdConfig.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Aimd;
+
+/**
+ * Immutable tuning parameters for the per-type AIMD load handler.
+ *
+ * Unlike the scalar handler, this tracks a target per job type. Floors and absolute latency
+ * thresholds can be overridden per type: keys are the bare worker name (e.g. "SmartScan"), matching
+ * the normalized type key produced by PerTypeIntervalStats. Bedrock-PHP stays generic — the caller
+ * (e.g. Salt config) supplies any app-specific overrides.
+ */
+final class PerTypeAimdConfig
+{
+    /**
+     * @param array<string, int>   $criticalTypeFloors   bare job name => guaranteed minimum target
+     * @param array<string, float> $maxSafeTimeOverrides  bare job name => per-type maxSafeTime (seconds)
+     */
+    public function __construct(
+        // Fraction slower this interval must be vs the previous one to back a type off.
+        public readonly float $backoffThreshold = 1.1,
+        // Fraction of an interval during which a second backoff of the same type is suppressed.
+        public readonly float $doubleBackoffPreventionIntervalFraction = 1.0,
+        // Length (seconds) of the averaging interval.
+        public readonly float $intervalDurationSeconds = 10.0,
+        // Jobs added to a type's target per second while ramping up.
+        public readonly float $jobsToAddPerSecond = 1.0,
+        // Multiplier applied to a type's target on a relative (accelerating) backoff.
+        public readonly float $multiplicativeDecreaseFraction = 0.8,
+        // Harder multiplier applied when a type exceeds its absolute maxSafeTime.
+        public readonly float $absoluteDecreaseFraction = 0.5,
+        // Absolute per-job duration (seconds) above which a type is unhealthy regardless of trend.
+        // A value <= 0 disables the absolute check.
+        public readonly float $maxSafeTime = 30.0,
+        // Default per-type floor. Kept low so many job types don't sum to a huge fleet minimum.
+        public readonly int $defaultTypeFloor = 1,
+        public readonly array $criticalTypeFloors = [],
+        public readonly array $maxSafeTimeOverrides = [],
+        // Safety ceiling on how many jobs a single GetJobs call may request.
+        public readonly int $maxJobsPerFetch = 1000,
+    ) {
+    }
+
+    /**
+     * The floor for a type: its critical override if set, otherwise the default.
+     */
+    public function floorFor(string $type): int
+    {
+        return $this->criticalTypeFloors[$type] ?? $this->defaultTypeFloor;
+    }
+
+    /**
+     * The absolute latency threshold for a type: its override if set, otherwise the default.
+     */
+    public function maxSafeTimeFor(string $type): float
+    {
+        return $this->maxSafeTimeOverrides[$type] ?? $this->maxSafeTime;
+    }
+}

--- a/src/Aimd/PerTypeAimdController.php
+++ b/src/Aimd/PerTypeAimdController.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Aimd;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Per-type AIMD load handler for BedrockWorkerManager.
+ *
+ * Where AimdController keeps a single global target, this keeps a target per job type and runs the
+ * AIMD loop independently for each. That fixes the "fast jobs mask slow jobs" failure: a slow job
+ * type is measured against its own history, so it backs off even while thousands of fast jobs of
+ * other types keep the aggregate looking healthy.
+ *
+ * Two changes beyond scalar AIMD:
+ *  - a type backs off on an ABSOLUTE latency threshold (maxSafeTime), not just when it is
+ *    accelerating, and additive increase is suppressed while a type is over that threshold; and
+ *  - the floor is per type (low by default, with a higher guaranteed floor for critical types), so
+ *    a flooding type can be throttled hard while critical jobs keep flowing.
+ *
+ * Like AimdController, all database and clock access happens in the caller and is passed in, so the
+ * class is pure and unit testable.
+ *
+ * NOTE: decide() returns the aggregate number of jobs to fetch (the sum of each type's headroom).
+ * Because GetJobs returns a mix the caller does not choose, fully enforcing a single type's target
+ * also needs a fork-time admission gate; that is a follow-up. Until then, per-type backoff still
+ * reduces how much we pull overall when a type is unhealthy.
+ */
+final class PerTypeAimdController implements AimdTargetReporter
+{
+    /** @var array<string, float> target job count per type */
+    private array $targets = [];
+
+    /** @var array<string, float> last backoff time per type */
+    private array $lastBackoffs = [];
+
+    /** The time decide() last ran, used to scale the additive increase. */
+    private float $lastRun;
+
+    public function __construct(
+        private readonly PerTypeAimdConfig $config,
+        float $now,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+        $this->lastRun = $now;
+    }
+
+    /**
+     * The per-type targets, exposed for stats/logging and testing.
+     *
+     * @return array<string, float>
+     */
+    public function getTargets(): array
+    {
+        return $this->targets;
+    }
+
+    public function getTarget(): float
+    {
+        return array_sum($this->targets);
+    }
+
+    /**
+     * Update each type's target from its own timing snapshot and return the total number of jobs it
+     * is safe to queue now (summed headroom across types, clamped to a safety ceiling).
+     *
+     * @param array<string, PerTypeIntervalStats> $statsByType
+     */
+    public function decide(array $statsByType, float $now): int
+    {
+        $timeSinceLastRun = $now - $this->lastRun;
+        $this->lastRun = $now;
+
+        $jobsToQueue = 0;
+        foreach ($statsByType as $type => $stats) {
+            $floor = $this->config->floorFor($type);
+            if (!isset($this->targets[$type])) {
+                $this->targets[$type] = (float) $floor;
+            }
+
+            // Not enough data to compare speeds this interval; hold the target and add its headroom.
+            if ($stats->lastIntervalCount === 0 || $stats->previousIntervalCount === 0) {
+                $jobsToQueue += $this->headroom($type, $stats);
+                continue;
+            }
+
+            $maxSafeTime = $this->config->maxSafeTimeFor($type);
+            $tooSlowAbsolute = $maxSafeTime > 0.0 && $stats->lastIntervalAverage > $maxSafeTime;
+            $tooSlowRelative = $stats->lastIntervalAverage > ($stats->previousIntervalAverage * $this->config->backoffThreshold);
+
+            if ($tooSlowAbsolute || $tooSlowRelative) {
+                // Multiplicative decrease, unless we backed this type off very recently. Back off
+                // harder when it is over the absolute threshold. Additive increase is implicitly
+                // suppressed while over maxSafeTime because we never reach the else branch.
+                if (($this->lastBackoffs[$type] ?? 0.0) < $now - ($this->config->intervalDurationSeconds * $this->config->doubleBackoffPreventionIntervalFraction)) {
+                    $factor = $tooSlowAbsolute
+                        ? min($this->config->multiplicativeDecreaseFraction, $this->config->absoluteDecreaseFraction)
+                        : $this->config->multiplicativeDecreaseFraction;
+                    $this->targets[$type] = max($this->targets[$type] * $factor, (float) $floor);
+                    $this->lastBackoffs[$type] = $now;
+                    $this->logger?->info('[AIMD] Backing off type target.', [
+                        'type' => $type,
+                        'target' => $this->targets[$type],
+                        'lastIntervalAverage' => $stats->lastIntervalAverage,
+                        'reason' => $tooSlowAbsolute ? 'maxSafeTime' : 'accelerating',
+                    ]);
+                }
+            } else {
+                // Ramp up, but don't outrun 2x the currently active jobs of this type.
+                if (($this->targets[$type] + $timeSinceLastRun * $this->config->jobsToAddPerSecond) < $stats->numActive * 2) {
+                    $this->targets[$type] += $timeSinceLastRun * $this->config->jobsToAddPerSecond;
+                }
+                $this->logger?->info('[AIMD] Congestion Avoidance for type.', ['type' => $type, 'target' => $this->targets[$type]]);
+            }
+
+            $jobsToQueue += $this->headroom($type, $stats);
+        }
+
+        return min($jobsToQueue, $this->config->maxJobsPerFetch);
+    }
+
+    private function headroom(string $type, PerTypeIntervalStats $stats): int
+    {
+        return intval(max($this->targets[$type] - $stats->numActive, 0));
+    }
+}

--- a/src/Aimd/PerTypeAimdController.php
+++ b/src/Aimd/PerTypeAimdController.php
@@ -82,20 +82,24 @@ final class PerTypeAimdController implements AimdTargetReporter
                 $this->targets[$type] = (float) $floor;
             }
 
-            // Not enough data to compare speeds this interval; hold the target and add its headroom.
-            if ($stats->lastIntervalCount === 0 || $stats->previousIntervalCount === 0) {
+            // Need at least one finished job this interval to have any latency signal for this type.
+            if ($stats->lastIntervalCount === 0) {
                 $jobsToQueue += $this->headroom($type, $stats);
                 continue;
             }
 
             $maxSafeTime = $this->config->maxSafeTimeFor($type);
             $tooSlowAbsolute = $maxSafeTime > 0.0 && $stats->lastIntervalAverage > $maxSafeTime;
-            $tooSlowRelative = $stats->lastIntervalAverage > ($stats->previousIntervalAverage * $this->config->backoffThreshold);
+            // The relative (accelerating) signal needs a previous interval to compare against; the
+            // absolute signal does not, so a type that only finishes jobs sporadically still backs
+            // off on a single slow interval.
+            $tooSlowRelative = $stats->previousIntervalCount > 0
+                && $stats->lastIntervalAverage > ($stats->previousIntervalAverage * $this->config->backoffThreshold);
 
             if ($tooSlowAbsolute || $tooSlowRelative) {
                 // Multiplicative decrease, unless we backed this type off very recently. Back off
                 // harder when it is over the absolute threshold. Additive increase is implicitly
-                // suppressed while over maxSafeTime because we never reach the else branch.
+                // suppressed while over maxSafeTime because we never reach the ramp branch.
                 if (($this->lastBackoffs[$type] ?? 0.0) < $now - ($this->config->intervalDurationSeconds * $this->config->doubleBackoffPreventionIntervalFraction)) {
                     $factor = $tooSlowAbsolute
                         ? min($this->config->multiplicativeDecreaseFraction, $this->config->absoluteDecreaseFraction)
@@ -109,8 +113,9 @@ final class PerTypeAimdController implements AimdTargetReporter
                         'reason' => $tooSlowAbsolute ? 'maxSafeTime' : 'accelerating',
                     ]);
                 }
-            } else {
-                // Ramp up, but don't outrun 2x the currently active jobs of this type.
+            } elseif ($stats->previousIntervalCount > 0) {
+                // Healthy and we have a previous interval to compare against: ramp up, but don't
+                // outrun 2x the currently active jobs of this type.
                 if (($this->targets[$type] + $timeSinceLastRun * $this->config->jobsToAddPerSecond) < $stats->numActive * 2) {
                     $this->targets[$type] += $timeSinceLastRun * $this->config->jobsToAddPerSecond;
                 }

--- a/src/Aimd/PerTypeAimdController.php
+++ b/src/Aimd/PerTypeAimdController.php
@@ -74,7 +74,9 @@ final class PerTypeAimdController implements AimdTargetReporter
         $this->lastRun = $now;
 
         $jobsToQueue = 0;
+        $totalActive = 0;
         foreach ($statsByType as $type => $stats) {
+            $totalActive += $stats->numActive;
             $floor = $this->config->floorFor($type);
             if (!isset($this->targets[$type])) {
                 $this->targets[$type] = (float) $floor;
@@ -117,6 +119,10 @@ final class PerTypeAimdController implements AimdTargetReporter
 
             $jobsToQueue += $this->headroom($type, $stats);
         }
+
+        // Keep a global baseline flowing so brand-new job types get discovered and BWM never wedges
+        // on a fresh localJobs DB (no known types => no per-type headroom => nothing fetched).
+        $jobsToQueue = max($jobsToQueue, $this->config->minSafeJobs - $totalActive);
 
         return min($jobsToQueue, $this->config->maxJobsPerFetch);
     }

--- a/src/Aimd/PerTypeIntervalStats.php
+++ b/src/Aimd/PerTypeIntervalStats.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Aimd;
+
+/**
+ * A per-type snapshot of local job timing for a single control loop, the per-type analogue of
+ * AimdIntervalStats. Instances are keyed by normalized (bare) job type and handed to
+ * PerTypeAimdController::decide().
+ */
+final class PerTypeIntervalStats
+{
+    public function __construct(
+        public readonly int $numActive,
+        public readonly int $lastIntervalCount,
+        public readonly float $lastIntervalAverage,
+        public readonly int $previousIntervalCount,
+        public readonly float $previousIntervalAverage,
+    ) {
+    }
+
+    /**
+     * Builds a map of normalized-type => PerTypeIntervalStats from three `GROUP BY jobName` result
+     * sets read out of the localJobs DB.
+     *
+     * Job names are normalized to the bare worker name (e.g. "www-prod/SmartScan" and
+     * "www-prod/SmartScan?email=a" both become "SmartScan") so all invocations of a job type roll
+     * up together. If two stored names normalize to the same type, their counts are summed and
+     * their averages combined as a count-weighted mean.
+     *
+     * @param array<int, array<int, mixed>> $activeRows rows of [jobName, count]
+     * @param array<int, array<int, mixed>> $lastRows   rows of [jobName, count, avg]
+     * @param array<int, array<int, mixed>> $prevRows   rows of [jobName, count, avg]
+     *
+     * @return array<string, self> keyed by normalized job type
+     */
+    public static function fromGroupedRows(array $activeRows, array $lastRows, array $prevRows): array
+    {
+        $active = self::indexCounts($activeRows);
+        [$lastCount, $lastAvg] = self::indexCountAvg($lastRows);
+        [$prevCount, $prevAvg] = self::indexCountAvg($prevRows);
+
+        $types = array_unique(array_merge(array_keys($active), array_keys($lastCount), array_keys($prevCount)));
+
+        $result = [];
+        foreach ($types as $type) {
+            $result[$type] = new self(
+                $active[$type] ?? 0,
+                $lastCount[$type] ?? 0,
+                $lastAvg[$type] ?? 0.0,
+                $prevCount[$type] ?? 0,
+                $prevAvg[$type] ?? 0.0,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int, array<int, mixed>> $rows rows of [jobName, count]
+     *
+     * @return array<string, int> normalized type => summed count
+     */
+    private static function indexCounts(array $rows): array
+    {
+        $counts = [];
+        foreach ($rows as $row) {
+            $type = self::normalizeName((string) ($row[0] ?? ''));
+            $counts[$type] = ($counts[$type] ?? 0) + intval($row[1] ?? 0);
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param array<int, array<int, mixed>> $rows rows of [jobName, count, avg]
+     *
+     * @return array{0: array<string, int>, 1: array<string, float>} [summed counts, count-weighted averages]
+     */
+    private static function indexCountAvg(array $rows): array
+    {
+        $counts = [];
+        $weightedSums = [];
+        foreach ($rows as $row) {
+            $type = self::normalizeName((string) ($row[0] ?? ''));
+            $count = intval($row[1] ?? 0);
+            $counts[$type] = ($counts[$type] ?? 0) + $count;
+            $weightedSums[$type] = ($weightedSums[$type] ?? 0.0) + floatval($row[2] ?? 0.0) * $count;
+        }
+
+        $averages = [];
+        foreach ($counts as $type => $count) {
+            $averages[$type] = $count > 0 ? $weightedSums[$type] / $count : 0.0;
+        }
+
+        return [$counts, $averages];
+    }
+
+    /**
+     * Reduces a stored job name to its bare worker name: strips any "?params" and the environment
+     * prefix, mirroring how BedrockWorkerManager resolves the worker class from a job name.
+     */
+    private static function normalizeName(string $name): string
+    {
+        $path = explode('?', $name)[0];
+        $segments = explode('/', $path);
+
+        return $segments[1] ?? $path;
+    }
+}

--- a/src/LocalDB.php
+++ b/src/LocalDB.php
@@ -91,6 +91,39 @@ class LocalDB
     }
 
     /**
+     * Runs a read query and returns every matching row as a numeric array, unlike read() which
+     * returns only the first row. Used for GROUP BY queries (e.g. per-type job stats).
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    public function readAll(string $query): array
+    {
+        $result = null;
+        while (true) {
+            try {
+                $result = $this->handle->query($query);
+                break;
+            } catch (Exception $e) {
+                if ($e->getMessage() === 'database is locked') {
+                    $this->logger->info('Query failed, retrying', ['query' => $query, 'error' => $e->getMessage()]);
+                } else {
+                    $this->logger->info('Query failed, not retrying', ['query' => $query, 'error' => $e->getMessage()]);
+                    throw $e;
+                }
+            }
+        }
+
+        $rows = [];
+        if ($result) {
+            while (($row = $result->fetchArray(SQLITE3_NUM)) !== false) {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
      * Runs a write query on a local database.
      */
     public function write(string $query)

--- a/tests/Aimd/PerTypeAimdControllerTest.php
+++ b/tests/Aimd/PerTypeAimdControllerTest.php
@@ -212,4 +212,31 @@ final class PerTypeAimdControllerTest extends TestCase
         // Then it is clamped to the ceiling
         $this->assertSame(5, $result);
     }
+
+    public function testAbsoluteBackoffFiresEvenWithNoPreviousInterval(): void
+    {
+        // Given a type ramped up to 5
+        $c = $this->controller();
+        $this->rampFourTicks($c, ['Y']);
+
+        // When it finishes slow jobs this interval but had none the previous interval (sparse
+        // completions — the common case for slow jobs)
+        $c->decide(['Y' => $this->stats(100, 3, 40.0, 0, 0.0)], self::START + 5);
+
+        // Then the absolute threshold still backs it off — it does not wait for two consecutive
+        // intervals with completions
+        $this->assertEqualsWithDelta(2.5, $c->getTargets()['Y'], 1e-9);
+    }
+
+    public function testNoRampWithoutAPreviousIntervalToCompare(): void
+    {
+        // Given a fresh type that finished fast jobs this interval but has no previous interval
+        $c = $this->controller();
+
+        // When we decide (fast, but no comparison data and not over maxSafeTime)
+        $c->decide(['Y' => $this->stats(100, 5, 1.0, 0, 0.0)], self::START + 1);
+
+        // Then it holds at the floor rather than ramping on a single unverified interval
+        $this->assertSame(1.0, $c->getTargets()['Y']);
+    }
 }

--- a/tests/Aimd/PerTypeAimdControllerTest.php
+++ b/tests/Aimd/PerTypeAimdControllerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Tests\Aimd;
+
+use Expensify\Bedrock\Aimd\PerTypeAimdConfig;
+use Expensify\Bedrock\Aimd\PerTypeAimdController;
+use Expensify\Bedrock\Aimd\PerTypeIntervalStats;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the per-type AIMD load handler: each job type is paced from its own timing, a type
+ * backs off on an absolute latency threshold (not just when accelerating), and critical types keep
+ * a guaranteed floor while flooding types are throttled hard.
+ */
+final class PerTypeAimdControllerTest extends TestCase
+{
+    private const START = 1000.0;
+
+    private function controller(?PerTypeAimdConfig $config = null): PerTypeAimdController
+    {
+        return new PerTypeAimdController($config ?? new PerTypeAimdConfig(), self::START);
+    }
+
+    private function stats(int $active, int $lastCount, float $lastAvg, int $prevCount, float $prevAvg): PerTypeIntervalStats
+    {
+        return new PerTypeIntervalStats($active, $lastCount, $lastAvg, $prevCount, $prevAvg);
+    }
+
+    /**
+     * Run one healthy (fast, steady) tick for each named type with the given active count.
+     *
+     * @param array<int, string> $types
+     */
+    private function healthyTick(PerTypeAimdController $c, array $types, int $active, float $now): void
+    {
+        $map = [];
+        foreach ($types as $type) {
+            $map[$type] = $this->stats($active, 5, 1.0, 5, 1.0);
+        }
+        $c->decide($map, $now);
+    }
+
+    /**
+     * Ramp the named types up over four healthy ticks (START+1 .. START+4).
+     *
+     * @param array<int, string> $types
+     */
+    private function rampFourTicks(PerTypeAimdController $c, array $types): void
+    {
+        for ($i = 1; $i <= 4; $i++) {
+            $this->healthyTick($c, $types, 100, self::START + $i);
+        }
+    }
+
+    public function testInsufficientDataHoldsFloorAndReturnsHeadroom(): void
+    {
+        // Given a fresh controller and a type with no finished jobs this interval
+        $c = $this->controller();
+
+        // When we decide with no jobs active
+        $result = $c->decide(['X' => $this->stats(0, 0, 0.0, 0, 0.0)], self::START + 1);
+
+        // Then the type is seeded at the default floor and we return its headroom (floor - active)
+        $this->assertSame(1, $result);
+        $this->assertSame(1.0, $c->getTargets()['X']);
+    }
+
+    public function testHealthyTypeRampsUp(): void
+    {
+        // Given a fresh controller and plenty of active jobs so the 2x cap doesn't bind
+        $c = $this->controller();
+
+        // When one second passes on a healthy tick
+        $c->decide(['X' => $this->stats(100, 5, 1.0, 5, 1.0)], self::START + 1);
+
+        // Then the type's target ramps up from the floor by jobsToAddPerSecond
+        $this->assertEqualsWithDelta(2.0, $c->getTargets()['X'], 1e-9);
+    }
+
+    public function testSlowTypeBacksOffWhileFastTypeKeepsRampingUp(): void
+    {
+        // Given both a fast and a slow type ramped up to a target of 5
+        $c = $this->controller();
+        $this->rampFourTicks($c, ['fast', 'slow']);
+
+        // When the slow type exceeds the absolute maxSafeTime (40s > 30s) but the fast one stays quick
+        $c->decide([
+            'fast' => $this->stats(100, 5, 0.5, 5, 0.5),
+            'slow' => $this->stats(100, 5, 40.0, 5, 40.0),
+        ], self::START + 5);
+
+        // Then the slow type backs off on its OWN latency while the fast type keeps ramping —
+        // exactly the "fast jobs mask slow jobs" case the aggregate handler could not catch.
+        $this->assertEqualsWithDelta(6.0, $c->getTargets()['fast'], 1e-9);
+        $this->assertEqualsWithDelta(2.5, $c->getTargets()['slow'], 1e-9);
+    }
+
+    public function testAbsoluteMaxSafeTimeBacksOffASteadyPlateau(): void
+    {
+        // Given a type ramped up to 5
+        $c = $this->controller();
+        $this->rampFourTicks($c, ['Y']);
+
+        // When its latency sits high but steady (40s == 40s, so NOT accelerating)
+        $c->decide(['Y' => $this->stats(100, 5, 40.0, 5, 40.0)], self::START + 5);
+
+        // Then it still backs off (target drops, so ramp-up was suppressed) because the absolute
+        // threshold fires even when the derivative signal reads "healthy" — the July-8 failure mode.
+        $this->assertEqualsWithDelta(2.5, $c->getTargets()['Y'], 1e-9);
+    }
+
+    public function testPerTypeOverrideKeepsLegitimatelySlowJobHealthy(): void
+    {
+        // Given a per-type override that treats SmartScan as fine up to 180s
+        $c = $this->controller(new PerTypeAimdConfig(maxSafeTimeOverrides: ['SmartScan' => 180.0]));
+        $this->rampFourTicks($c, ['SmartScan']);
+
+        // When SmartScan runs at 40s (over the 30s global default, but under its 180s override)
+        $c->decide(['SmartScan' => $this->stats(100, 5, 40.0, 5, 40.0)], self::START + 5);
+
+        // Then it is NOT backed off — it keeps ramping, no false positive
+        $this->assertEqualsWithDelta(6.0, $c->getTargets()['SmartScan'], 1e-9);
+    }
+
+    public function testCriticalTypeKeepsFloorWhileFloodingTypeCollapses(): void
+    {
+        // Given a critical type with a guaranteed floor of 10 and a non-critical flooding type
+        $c = $this->controller(new PerTypeAimdConfig(criticalTypeFloors: ['SendValidateCode' => 10]));
+        $this->rampFourTicks($c, ['SendValidateCode', 'Bad']);
+
+        // When both get slow enough to back off hard
+        $c->decide([
+            'SendValidateCode' => $this->stats(100, 5, 40.0, 5, 40.0),
+            'Bad' => $this->stats(100, 5, 40.0, 5, 40.0),
+        ], self::START + 5);
+
+        // Then the critical type is clamped at its floor (14 * 0.5 = 7, floored to 10) while the
+        // flooding type is free to collapse toward the low default floor (5 * 0.5 = 2.5)
+        $this->assertSame(10.0, $c->getTargets()['SendValidateCode']);
+        $this->assertEqualsWithDelta(2.5, $c->getTargets()['Bad'], 1e-9);
+    }
+
+    public function testDoubleBackoffPreventedPerType(): void
+    {
+        // Given a type that just backed off once (5 -> 2.5)
+        $c = $this->controller();
+        $this->rampFourTicks($c, ['Y']);
+        $c->decide(['Y' => $this->stats(100, 5, 40.0, 5, 40.0)], self::START + 5);
+        $this->assertEqualsWithDelta(2.5, $c->getTargets()['Y'], 1e-9);
+
+        // When another backoff-worthy tick arrives within the same interval
+        $c->decide(['Y' => $this->stats(100, 5, 40.0, 5, 40.0)], self::START + 6);
+
+        // Then it does not back off again
+        $this->assertEqualsWithDelta(2.5, $c->getTargets()['Y'], 1e-9);
+    }
+
+    public function testAggregateFetchIsSumOfPerTypeHeadroom(): void
+    {
+        // Given two types each seeded at a floor of 10 with 3 jobs active
+        $c = $this->controller(new PerTypeAimdConfig(criticalTypeFloors: ['A' => 10, 'B' => 10]));
+
+        // When we decide with no finished jobs (targets held at the floor)
+        $result = $c->decide([
+            'A' => $this->stats(3, 0, 0.0, 0, 0.0),
+            'B' => $this->stats(3, 0, 0.0, 0, 0.0),
+        ], self::START + 1);
+
+        // Then the fetch count is the sum of each type's headroom: (10 - 3) + (10 - 3) = 14
+        $this->assertSame(14, $result);
+    }
+
+    public function testAggregateFetchClampedToMaxJobsPerFetch(): void
+    {
+        // Given the same two types but a low per-fetch ceiling of 5
+        $c = $this->controller(new PerTypeAimdConfig(criticalTypeFloors: ['A' => 10, 'B' => 10], maxJobsPerFetch: 5));
+
+        // When the summed headroom would be 14
+        $result = $c->decide([
+            'A' => $this->stats(3, 0, 0.0, 0, 0.0),
+            'B' => $this->stats(3, 0, 0.0, 0, 0.0),
+        ], self::START + 1);
+
+        // Then it is clamped to the ceiling
+        $this->assertSame(5, $result);
+    }
+}

--- a/tests/Aimd/PerTypeAimdControllerTest.php
+++ b/tests/Aimd/PerTypeAimdControllerTest.php
@@ -54,17 +54,43 @@ final class PerTypeAimdControllerTest extends TestCase
         }
     }
 
-    public function testInsufficientDataHoldsFloorAndReturnsHeadroom(): void
+    public function testColdStartFetchesGlobalBaselineToDiscoverWork(): void
     {
-        // Given a fresh controller and a type with no finished jobs this interval
+        // Given a fresh controller and an empty local jobs DB (no known types yet)
+        $c = $this->controller();
+
+        // When we decide with no per-type stats at all
+        $result = $c->decide([], self::START + 1);
+
+        // Then we still fetch the global baseline (minSafeJobs) so new job types get discovered —
+        // without this, BWM would never pull anything on a fresh DB.
+        $this->assertSame(10, $result);
+    }
+
+    public function testInsufficientDataHoldsFloorAndFetchesBaseline(): void
+    {
+        // Given a fresh controller and a known type with no finished jobs this interval
         $c = $this->controller();
 
         // When we decide with no jobs active
         $result = $c->decide(['X' => $this->stats(0, 0, 0.0, 0, 0.0)], self::START + 1);
 
-        // Then the type is seeded at the default floor and we return its headroom (floor - active)
-        $this->assertSame(1, $result);
+        // Then the type is held at the default floor, and the fetch is lifted to the global
+        // baseline (minSafeJobs=10) since the host is otherwise idle
         $this->assertSame(1.0, $c->getTargets()['X']);
+        $this->assertSame(10, $result);
+    }
+
+    public function testBaselineDoesNotInflateFetchWhenBusy(): void
+    {
+        // Given a type with lots of active jobs (host is busy, above the baseline)
+        $c = $this->controller();
+
+        // When a healthy tick leaves no per-type headroom (target 2 < 100 active)
+        $result = $c->decide(['X' => $this->stats(100, 5, 1.0, 5, 1.0)], self::START + 1);
+
+        // Then the baseline floor (minSafeJobs - 100 active) is negative, so it does not add fetch
+        $this->assertSame(0, $result);
     }
 
     public function testHealthyTypeRampsUp(): void

--- a/tests/Aimd/PerTypeIntervalStatsTest.php
+++ b/tests/Aimd/PerTypeIntervalStatsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Tests\Aimd;
+
+use Expensify\Bedrock\Aimd\PerTypeIntervalStats;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for how raw `GROUP BY jobName` rows are normalized and merged into per-type stats.
+ */
+final class PerTypeIntervalStatsTest extends TestCase
+{
+    public function testNormalizesFullNameToBareType(): void
+    {
+        // Given an active-jobs row with the full env-prefixed name
+        // When we build the per-type stats
+        $byType = PerTypeIntervalStats::fromGroupedRows([['www-prod/SmartScan', 5]], [], []);
+
+        // Then it is keyed by the bare worker name
+        $this->assertArrayHasKey('SmartScan', $byType);
+        $this->assertSame(5, $byType['SmartScan']->numActive);
+    }
+
+    public function testJobsWithDifferentParamsCollapseToOneType(): void
+    {
+        // Given the same job type appearing with different query params
+        $activeRows = [
+            ['www-prod/HandleUberEmployeeManagementEvent?email=a', 2],
+            ['www-prod/HandleUberEmployeeManagementEvent?email=b', 3],
+        ];
+
+        // When we build the per-type stats
+        $byType = PerTypeIntervalStats::fromGroupedRows($activeRows, [], []);
+
+        // Then they roll up into a single type with the counts summed
+        $this->assertSame(['HandleUberEmployeeManagementEvent'], array_keys($byType));
+        $this->assertSame(5, $byType['HandleUberEmployeeManagementEvent']->numActive);
+    }
+
+    public function testAveragesAreCountWeightedWhenNamesMerge(): void
+    {
+        // Given two stored names that normalize to the same type with different counts and averages
+        $lastRows = [
+            ['www-prod/X', 10, 2.0],
+            ['www-stag/X', 30, 6.0],
+        ];
+
+        // When we build the per-type stats
+        $byType = PerTypeIntervalStats::fromGroupedRows([], $lastRows, []);
+
+        // Then counts sum and the average is the count-weighted mean: (10*2 + 30*6) / 40 = 5.0
+        $this->assertSame(40, $byType['X']->lastIntervalCount);
+        $this->assertEqualsWithDelta(5.0, $byType['X']->lastIntervalAverage, 1e-9);
+    }
+
+    public function testTypesPresentInOnlySomeWindowsGetZeros(): void
+    {
+        // Given type A only active, and type B only finished last interval
+        $byType = PerTypeIntervalStats::fromGroupedRows(
+            [['www-prod/A', 4]],
+            [['www-prod/B', 6, 1.5]],
+            [],
+        );
+
+        // Then both types exist, with zeros for the windows they were absent from
+        $this->assertSame(4, $byType['A']->numActive);
+        $this->assertSame(0, $byType['A']->lastIntervalCount);
+        $this->assertSame(0, $byType['B']->numActive);
+        $this->assertSame(6, $byType['B']->lastIntervalCount);
+        $this->assertSame(0, $byType['B']->previousIntervalCount);
+    }
+}

--- a/tests/LocalDBReadAllTest.php
+++ b/tests/LocalDBReadAllTest.php
@@ -7,6 +7,7 @@ namespace Expensify\Bedrock\Tests;
 use Expensify\Bedrock\LocalDB;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use stdClass;
 
 /**
  * Tests for LocalDB::readAll(), the multi-row read added for per-type GROUP BY queries.
@@ -19,7 +20,7 @@ final class LocalDBReadAllTest extends TestCase
     protected function setUp(): void
     {
         $this->path = tempnam(sys_get_temp_dir(), 'localdb-test-');
-        $this->db = new LocalDB($this->path, new NullLogger(), new \stdClass());
+        $this->db = new LocalDB($this->path, new NullLogger(), new stdClass());
         $this->db->open();
         $this->db->write('CREATE TABLE t (name TEXT, n INTEGER);');
         $this->db->write("INSERT INTO t (name, n) VALUES ('a', 1), ('a', 2), ('b', 5);");

--- a/tests/LocalDBReadAllTest.php
+++ b/tests/LocalDBReadAllTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Tests;
+
+use Expensify\Bedrock\LocalDB;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests for LocalDB::readAll(), the multi-row read added for per-type GROUP BY queries.
+ */
+final class LocalDBReadAllTest extends TestCase
+{
+    private string $path;
+    private LocalDB $db;
+
+    protected function setUp(): void
+    {
+        $this->path = tempnam(sys_get_temp_dir(), 'localdb-test-');
+        $this->db = new LocalDB($this->path, new NullLogger(), new \stdClass());
+        $this->db->open();
+        $this->db->write('CREATE TABLE t (name TEXT, n INTEGER);');
+        $this->db->write("INSERT INTO t (name, n) VALUES ('a', 1), ('a', 2), ('b', 5);");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->db->close();
+        @unlink($this->path);
+    }
+
+    public function testReadAllReturnsEveryRow(): void
+    {
+        // When we run a grouped query that yields multiple rows
+        $rows = $this->db->readAll('SELECT name, SUM(n) FROM t GROUP BY name ORDER BY name;');
+
+        // Then every row is returned as a numeric array
+        $this->assertSame([['a', 3], ['b', 5]], $rows);
+    }
+
+    public function testReadStillReturnsOnlyTheFirstRow(): void
+    {
+        // Given the same multi-row query, the single-row read() returns just the first row
+        $row = $this->db->read('SELECT name, SUM(n) FROM t GROUP BY name ORDER BY name;');
+
+        $this->assertSame(['a', 3], $row);
+    }
+
+    public function testReadAllReturnsEmptyArrayWhenNoRows(): void
+    {
+        // When a query matches nothing
+        $rows = $this->db->readAll("SELECT name, n FROM t WHERE name = 'nope';");
+
+        // Then we get an empty array, not false
+        $this->assertSame([], $rows);
+    }
+}


### PR DESCRIPTION
# Explanation of Change

Per-type AIMD for the Bedrock Worker Manager, so a single slow or flooding job type can no longer take down shared backends (context: the Uber/Nutanix self-DDOS, [Expensify#661712](https://github.com/Expensify/Expensify/issues/661712)).

- Extracts the existing scalar AIMD out of `BedrockWorkerManager.php` into a pure, unit-testable `AimdController` (behavior-preserving), and adds a PHPUnit harness + CI job (the repo had no tests).
- Adds a flag-gated (`--enablePerTypeAimd`) per-type handler that tracks a target **per job type**, so a slow type backs off on its own latency instead of being masked by fast jobs.
- Wires up the previously-dead `--maxSafeTime` as an **absolute** latency backoff (with ramp-up suppression), plus a low per-type floor and protected floors for critical jobs (`--criticalTypeFloors`) and per-type thresholds (`--maxSafeTimeOverrides`), supplied as JSON so app-specific job names stay out of this generic library.
- Adds `LocalDB::readAll()` for the per-type `GROUP BY` reads.
- 16 unit tests cover the per-type behavior.

**Off by default:** the scalar handler stays the behavior until `--enablePerTypeAimd` is set, so this is safe to land and roll out gradually.

## What this PR solves / does not solve

**Solves — the system now NOTICES the bad job type early.** Old (scalar) AIMD averaged all jobs together: 5,000 fast jobs kept the average looking healthy, so it never realized `SendFetchableOnyxUpdates` was the problem and kept pulling it at full speed (even ramping up). It was blind. Per-type AIMD measures `SendFetchableOnyxUpdates` against its own history; its average shoots past 30s, so we back that type's target down toward the floor and stop it from ramping — while leaving the fast jobs alone. We identify the culprit and stop actively feeding it more budget within ~10–20 seconds instead of never. That's the exact failure from the fire, fixed.

**Does NOT solve — it can't stop jobs already in the queue from slipping through.** After backing `SendFetchableOnyxUpdates` down to "run ~1":

- The healthy fast jobs open a fetch budget of, say, 35 jobs.
- We ask Bedrock for "35 jobs, any type." But the queue holds 10,000 heavy jobs, so Bedrock hands back 35 heavy ones, and we launch all 35.
- We wanted 1; we ran 35.

So this PR makes the throttle a **soft** limit (it shrinks the total we pull), not a **hard** cap (it can't refuse the bad type specifically). The hard cap needs the fork-time admission gate (a follow-up PR): after those 35 come back, requeue 34 of them instead of running them.

| | This PR | Needs admission gate (follow-up) |
|---|---|---|
| Notice a slow type despite fast jobs masking it | ✅ | |
| Stop ramping up the bad type | ✅ | |
| Shrink the total jobs pulled during a flood | ✅ (partial) | |
| Hard cap on how many of the bad type run at once | | ❌ |

## Test Steps
1. I created a bedrock Job called SlowTestJob. It has nothing other than a log.
2. I queued 100 of these jobs. Ran bwm. Tailed the logs for `Congestion Avoidance for type`.
3. Confirmed i saw `Congestion Avoidance for type` for the job and it started ramping up,
```
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '1.5034158229828'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '1.5034158229828'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '1.5407197475433'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '1.5548987388611'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '2.0630359649658'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '2.5644588470459'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '3.0725469589233'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '3.5750317573547'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '3.5750317573547'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '3.6077847480774'
[info] [AIMD] Congestion Avoidance for type. ~~ type: 'SlowTestJob' target: '3.6146068572998'
```
So this shows up the congestion was detecting my job specifically, even even though other job types were there locally. We see from its target that it's ramping up, and it ended up with 3.6, meaning that at the time BWM safely thought it could run 3.6 of these jobs at a time. 

4. I updated SlowTestJob with a sleep of 40s. 
5. I queued 100 of these jobs. Ran bwm. Tailed the logs for `Backing off type target`.
6. Confirm that I saw this in the log as soon as the first set of jobs completed,
```
[info] [AIMD] Backing off type target. ~~ type: 'SlowTestJob' target: '1' lastIntervalAverage: '40.021671431405' reason: 'maxSafeTime'
```
This indicates that BWM believes that only one job of this can be picked up at a time, which is the current default minimum. It also shows us that the average time to complete one of the jobs is 40 seconds. 

### Related Issues
For https://github.com/Expensify/Expensify/issues/661712

## Deployment
- [ ] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
