### PR TITLE
QSP: update PHP to 8.3.32 in GitHub Actions

### DIFF
--- a/.github/workflows/bedrock-php.yml
+++ b/.github/workflows/bedrock-php.yml
@@ -28,7 +28,7 @@ jobs:
       uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
       with:
         tools: composer:v2.7.1
-        php-version: 8.3.31
+        php-version: 8.3.32
         coverage: none
       env:
         GITHUB_TOKEN: ${{ secrets.CODE_EXPENSIFY_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
       uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
       with:
         tools: composer:v2.7.1
-        php-version: 8.3.31
+        php-version: 8.3.32
         coverage: none
       env:
         GITHUB_TOKEN: ${{ secrets.CODE_EXPENSIFY_TOKEN }}


### PR DESCRIPTION
# Explanation of Change

(Neil's AI agent)

Quarterly Server Patching: our servers are moving from PHP `8.3.31` to `8.3.32`, so the GitHub Actions workflows need to install the same version to keep CI matched to production.

This bumps every `php-version:` in `bedrock-php.yml` from `8.3.31` to `8.3.32`.

Confirmed candidate version from virt1.lax:

```
nmetcalf@virt1.lax:~$ apt-cache policy php8.3-common
php8.3-common:
  Installed: 8.3.31-3+ubuntu24.04.1+deb.sury.org+1
  Candidate: 8.3.32-1+ubuntu24.04.1+deb.sury.org+1
```

### Related Issues

For https://github.com/Expensify/Expensify/issues/659200

## Deployment

This only changes GitHub Actions config, so no package publish is needed.

- [ ] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
