### PR TITLE
[WIP] Add backend-health gate to BWM

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -15,6 +15,7 @@ use Expensify\Bedrock\Exceptions\Jobs\IllegalAction;
 use Expensify\Bedrock\Exceptions\Jobs\RetryableException;
 use Expensify\Bedrock\Jobs;
 use Expensify\Bedrock\LocalDB;
+use Expensify\Bedrock\Status;
 
 /*
  * BedrockWorkerManager
@@ -46,7 +47,8 @@ $options = getopt('', ['maxLoad::', 'maxIterations::', 'jobName::', 'logger::', 
     'maxSafeTime::', 'localJobsDBPath::', 'debugThrottle', 'backoffThreshold::',
     'intervalDurationSeconds::', 'doubleBackoffPreventionIntervalFraction::', 'multiplicativeDecreaseFraction::',
     'jobsToAddPerSecond::', 'profileChangeThreshold::', 'enablePerTypeAimd',
-    'criticalTypeFloors::', 'maxSafeTimeOverrides::', ]);
+    'criticalTypeFloors::', 'maxSafeTimeOverrides::', 'maxBackendCommandCount::',
+    'healthCheckIntervalSeconds::', ]);
 
 $workerPath = $options['workerPath'] ?? null;
 if (!$workerPath) {
@@ -75,6 +77,12 @@ $enablePerTypeAimd = isset($options['enablePerTypeAimd']);
 // {"SmartScan":180}).
 $criticalTypeFloors = json_decode($options['criticalTypeFloors'] ?? '{}', true) ?: [];
 $maxSafeTimeOverrides = json_decode($options['maxSafeTimeOverrides'] ?? '{}', true) ?: [];
+
+// Backend-health gate (flag-gated OFF by default): pause fetching when the backend the jobs stress
+// is saturated. --maxBackendCommandCount is the threshold (0 disables the gate) and should be tuned
+// from baselines. The Status poll is cached for --healthCheckIntervalSeconds so we don't hammer it.
+$maxBackendCommandCount = intval($options['maxBackendCommandCount'] ?? 0);
+$healthCheckIntervalSeconds = floatval($options['healthCheckIntervalSeconds'] ?? 2.0);
 
 // The fraction of run time the current batch of jobs needs to be in relation to the previous batch to cause us to
 // back off our target number of jobs.
@@ -141,6 +149,14 @@ if ($enablePerTypeAimd) {
         $logger,
     );
 }
+
+// Backend-health gate. Polls the Status command of the backend the jobs stress and pauses fetching
+// when it is saturated — a real signal, unlike the local box's loadavg. Reuses the jobs client for
+// now; TODO(chirag-auth-health-gate): point it at Auth (the cluster that actually saturates) via a
+// dedicated client + a --healthCheckHosts config once that decision is settled.
+$healthStatus = new Status($bedrock);
+$lastHealthCheck = 0.0;
+$lastBackendCommandCount = 0;
 
 // Set up the database for the AIMD load handler.
 $localDB = new LocalDB($pathToDB, $logger, $stats);
@@ -211,10 +227,14 @@ try {
                 break 2;
             }
 
-            // Check if we can fork based on the load of our webservers
+            // Check if we can fork, based on backend health (primary) and our own host load (secondary).
             $load = sys_getloadavg()[0];
+            $backendCommandCount = getBackendCommandCount();
             $jobsToQueue = getNumberOfJobsToQueue();
-            if ($load > $maxLoad) {
+            if ($maxBackendCommandCount > 0 && $backendCommandCount > $maxBackendCommandCount) {
+                $logger->info('[AIMD] Backend saturated, pausing fetch and trying again in 1s.', ['backendCommandCount' => $backendCommandCount, 'maxBackendCommandCount' => $maxBackendCommandCount]);
+                sleep(1);
+            } elseif ($load > $maxLoad) {
                 $logger->info('[AIMD] Not safe to start a new job, load is too high, waiting 1s and trying again.', ['load' => $load, 'MAX_LOAD' => $maxLoad]);
                 sleep(1);
             } elseif ($jobsToQueue >= 3) {
@@ -561,6 +581,34 @@ try {
 }
 
 $logger->info('Stopped BedrockWorkerManager, will not wait for children');
+
+/**
+ * Returns the backend's current in-flight command count, polled from the Status command and cached
+ * for --healthCheckIntervalSeconds. Returns 0 when the gate is disabled (--maxBackendCommandCount<=0).
+ * Fails closed (treats the backend as saturated) when the health check errors, so we don't pile onto
+ * a dying node.
+ */
+function getBackendCommandCount(): int
+{
+    global $healthStatus, $lastHealthCheck, $lastBackendCommandCount, $healthCheckIntervalSeconds, $maxBackendCommandCount, $logger;
+
+    if ($maxBackendCommandCount <= 0) {
+        return 0;
+    }
+    $now = microtime(true);
+    if ($now - $lastHealthCheck < $healthCheckIntervalSeconds) {
+        return $lastBackendCommandCount;
+    }
+    $lastHealthCheck = $now;
+    try {
+        $lastBackendCommandCount = $healthStatus->getHealth()['commandCount'];
+    } catch (Throwable $e) {
+        $logger->warning('[AIMD] Backend health check failed; treating backend as saturated.', ['error' => $e->getMessage()]);
+        $lastBackendCommandCount = PHP_INT_MAX;
+    }
+
+    return $lastBackendCommandCount;
+}
 
 /**
  * Determines whether or not we call GetJob and try to start a new job

--- a/src/Status.php
+++ b/src/Status.php
@@ -14,6 +14,45 @@ class Status extends Plugin
      */
     public function ping()
     {
-        return $this->client->call("Ping");
+        return $this->client->call('Ping');
+    }
+
+    /**
+     * Reads a lightweight backend-health snapshot from the Status command, used by the AIMD load
+     * handler to pause fetching when the backend is saturated.
+     *
+     * @return array{state: string, commandCount: int, queueDepth: int}
+     */
+    public function getHealth()
+    {
+        return self::parseHealth($this->client->call('Status'));
+    }
+
+    /**
+     * Extracts the health fields from a Client::call() response. Pure (no I/O) so it can be unit
+     * tested. `queuedCommandList` may arrive already decoded (array) or as a JSON string depending
+     * on how the body was parsed, so both are handled.
+     *
+     * @param array $response a Client::call() response (['code' => int, 'headers' => [], 'body' => mixed])
+     *
+     * @return array{state: string, commandCount: int, queueDepth: int}
+     */
+    public static function parseHealth(array $response)
+    {
+        $body = $response['body'] ?? [];
+        if (!is_array($body)) {
+            $body = json_decode((string) $body, true) ?: [];
+        }
+
+        $queued = $body['queuedCommandList'] ?? [];
+        if (is_string($queued)) {
+            $queued = json_decode($queued, true) ?: [];
+        }
+
+        return [
+            'state' => (string) ($body['state'] ?? 'UNKNOWN'),
+            'commandCount' => intval($body['commandCount'] ?? 0),
+            'queueDepth' => is_array($queued) ? count($queued) : 0,
+        ];
     }
 }

--- a/tests/StatusHealthTest.php
+++ b/tests/StatusHealthTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Expensify\Bedrock\Tests;
+
+use Expensify\Bedrock\Status;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Status::parseHealth(), which extracts the backend-health fields the AIMD load handler
+ * gates on from a Bedrock Status response.
+ */
+final class StatusHealthTest extends TestCase
+{
+    public function testParsesAlreadyDecodedBody(): void
+    {
+        // Given a Status response whose body is already a decoded array
+        $response = ['code' => 200, 'body' => [
+            'state' => 'LEADING',
+            'commandCount' => '42',
+            'queuedCommandList' => ['CmdA', 'CmdB', 'CmdC'],
+        ]];
+
+        // When we parse it
+        $health = Status::parseHealth($response);
+
+        // Then the fields come through, with commandCount coerced to int and the queue depth counted
+        $this->assertSame('LEADING', $health['state']);
+        $this->assertSame(42, $health['commandCount']);
+        $this->assertSame(3, $health['queueDepth']);
+    }
+
+    public function testParsesQueuedCommandListWhenItIsAJsonString(): void
+    {
+        // Given a body where queuedCommandList arrived as a JSON string
+        $response = ['body' => ['state' => 'FOLLOWING', 'commandCount' => 5, 'queuedCommandList' => '["a","b"]']];
+
+        // When we parse it
+        $health = Status::parseHealth($response);
+
+        // Then the string is decoded and its entries counted
+        $this->assertSame(2, $health['queueDepth']);
+    }
+
+    public function testParsesRawJsonStringBody(): void
+    {
+        // Given a body that is still a raw JSON string
+        $response = ['body' => '{"state":"LEADING","commandCount":"7","queuedCommandList":[]}'];
+
+        // When we parse it
+        $health = Status::parseHealth($response);
+
+        // Then it is decoded and the fields extracted
+        $this->assertSame('LEADING', $health['state']);
+        $this->assertSame(7, $health['commandCount']);
+        $this->assertSame(0, $health['queueDepth']);
+    }
+
+    public function testDefaultsWhenFieldsMissing(): void
+    {
+        // Given a response with no usable body
+        // When we parse it
+        $health = Status::parseHealth([]);
+
+        // Then we get safe defaults
+        $this->assertSame('UNKNOWN', $health['state']);
+        $this->assertSame(0, $health['commandCount']);
+        $this->assertSame(0, $health['queueDepth']);
+    }
+}


### PR DESCRIPTION
# Explanation of Change

Adds the **backend-health gate** to the BWM — the durable half of the AIMD fix. Per-type AIMD (#263) is a *local, relative* pacer; this adds an *absolute* signal tied to the resource that actually saturates, so BWM stops pulling work when the backend is in trouble instead of watching the local box's loadavg (which stayed ~26/48 "Safe" throughout the 2026-07-08 fire while Auth CPU was pinned at ~100%).

- `Status::getHealth()` / `parseHealth()` — reads the backend's in-flight `commandCount` and queue depth from the `Status` command. `parseHealth()` is pure and unit-tested.
- Top-of-loop gate — pauses fetching when `commandCount > --maxBackendCommandCount` (**`0` = disabled, the default**). Cached poll (`--healthCheckIntervalSeconds`, default 2s); **fails closed** (treats an unreachable backend as saturated so we don't pile onto a dying node). The local `sys_getloadavg()` check is kept as a secondary guard.
- 4 new tests for `parseHealth`; full suite green (24 tests).

**Off by default** — merging changes nothing until `--maxBackendCommandCount` is set in Salt.

## Stacking / dependency

Based on the **#263 branch** (`aimd-extract-testable-controller`), so this diff shows only the gate. Retarget to `main` once #263 merges. Ships in the same bedrock-php line as per-type AIMD but is enabled separately (and later).

### Related Issues

For https://github.com/Expensify/Expensify/issues/661712

## Deployment

- [ ] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
