### PR TITLE
Do not retry timeouts in bedrock/auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.4",
+    "version": "2.3.5",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ namespace Expensify\Bedrock;
 
 use Expensify\Bedrock\Exceptions\BedrockError;
 use Expensify\Bedrock\Exceptions\ConnectionFailure;
+use Expensify\Bedrock\Exceptions\TimeoutError;
 use Expensify\Bedrock\Stats\NullStats;
 use Expensify\Bedrock\Stats\StatsInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -773,16 +774,9 @@ class Client implements LoggerAwareInterface
             $this->commitCount = (int) ($responseHeaders['commitCount'] ?? 0);
         }
 
-        // A command timeout (not a query timeout) is reported with a '555 Timeout' code line, optionally suffixed with
-        // the phase it timed out in ('555 Timeout peeking command', '555 Timeout processing command', etc.). We treat
-        // these as a ConnectionFailure so they get retried regardless of whether the command is idempotent, because the
-        // command timed out before committing and its transaction was rolled back, so no work was applied.
-        // The one exception is '555 Timeout postProcessing command': postProcess runs only after the command has
-        // already committed (200 OK), so retrying it would re-run an already-applied command and could double-apply a
-        // non-idempotent one. We let that case fall through and surface as a regular error.
-        // For any other error code/message we do not throw here, so it gets handled like any regular response.
-        if (str_starts_with($codeLine, '555 Timeout') && $codeLine !== '555 Timeout postProcessing command') {
-            throw new ConnectionFailure("Internal Bedrock command timeout ($codeLine)");
+        // If a command times out, we don't want to retry it every because it will probably time out in all servers
+        if (str_starts_with($codeLine, '555 Timeout')) {
+            throw new TimeoutError("Internal Bedrock command timeout ($codeLine)");
         }
 
         if ($codeLine === '500 Internal Server Error') {

--- a/src/Client.php
+++ b/src/Client.php
@@ -358,7 +358,10 @@ class Client implements LoggerAwareInterface
         try {
             $response = $this->doCall($method, $headers, $body);
         } catch (BedrockError $e) {
-            $this->recordCircuitFailure();
+            // Timeout errors should not trigger the circuit breaker because they are caused by one command timing out
+            if (!($e instanceof TimeoutError)) {
+                $this->recordCircuitFailure();
+            }
             throw $e;
         }
         $this->recordCircuitSuccess();
@@ -512,6 +515,9 @@ class Client implements LoggerAwareInterface
                     $this->logger->error('Bedrock\Client - Failed to connect or send the request; not retrying because we are out of retries', ['host' => $hostName, 'message' => $e->getMessage(), 'exception' => $e]);
                     $exception = $e;
                 }
+            } catch (TimeoutError $e) {
+                // Do not retry timeout errors because they are likely to timeout on all servers
+                $exception = $e;
             } catch (BedrockError $e) {
                 // This error happen after sending some data to the server, so we only can retry it if it is an idempotent command
                 $requestAlreadySent = true;
@@ -774,7 +780,7 @@ class Client implements LoggerAwareInterface
             $this->commitCount = (int) ($responseHeaders['commitCount'] ?? 0);
         }
 
-        // If a command times out, we don't want to retry it every because it will probably time out in all servers
+        // If a command times out, we don't want to retry it, as it will likely time out on all servers.
         if (str_starts_with($codeLine, '555 Timeout')) {
             throw new TimeoutError("Internal Bedrock command timeout ($codeLine)");
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -358,10 +358,7 @@ class Client implements LoggerAwareInterface
         try {
             $response = $this->doCall($method, $headers, $body);
         } catch (BedrockError $e) {
-            // Timeout errors should not trigger the circuit breaker because they are caused by one command timing out
-            if (!($e instanceof TimeoutError)) {
-                $this->recordCircuitFailure();
-            }
+            $this->recordCircuitFailure();
             throw $e;
         }
         $this->recordCircuitSuccess();

--- a/src/Exceptions/TimeoutError.php
+++ b/src/Exceptions/TimeoutError.php
@@ -2,11 +2,9 @@
 
 namespace Expensify\Bedrock\Exceptions;
 
-use Exception;
-
 /**
  * Thrown when a command times out
  */
-class TimeoutError extends Exception
+class TimeoutError extends BedrockError
 {
 }

--- a/src/Exceptions/TimeoutError.php
+++ b/src/Exceptions/TimeoutError.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Expensify\Bedrock\Exceptions;
+
+use Exception;
+
+/**
+ * Thrown when a command times out
+ */
+class TimeoutError extends Exception
+{
+}


### PR DESCRIPTION
Do not merge, I need to create the version after you approve

# Explanation of Change

When we timeout, we don't want to retry the command as it will probably time out again. We also don't want to mark the host as failed nor to trip the circuit breaker.

# Tests

I added a sleep to Get and called it via PHP, then checked:
- No retries were done
- Circuit breaker failure logged
- Logs:
```
2026-08-03T19:26:05.751310+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'Get' clusterName: 'auth' headers: '[limit: '10' timeout: '1' authToken: '<REDACTED>' returnValueList: 'transactionList' idempotent: '1' logParam: 'ionatan@expensify.com' urlToNewDot: 'https://dev.new.expensify.com:8082/' shouldReadUsingThreads: '1' shouldHandleOnyxUpdates: '1' isNewDotRequest: '' clientUpdateID: '0' isFromIntegrationServer: '' requestOrigin: '/caca.php' maxNumberOfUpdates: '500' requestID: 'nqxiAT' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500']'
2026-08-03T19:26:05.751368+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2026-08-03T19:26:05.751410+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2026-08-03T19:26:05.751446+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] Bedrock\Client - Opening new socket ~~ host: 'auth' cluster: 'auth' pid: '3633394'
2026-08-03T19:26:05.751560+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] Bedrock\Client - socket_connect returned error 115, waiting for connection to complete. ~~ host: 'auth'
2026-08-03T19:26:05.751759+00:00 expensidev-2404 bedrock: xxxxxx we@dont.know (BedrockServer.cpp:2392) _acceptSockets [main] [dbug] Accepting socket from '127.0.0.1:60994' on port '0.0.0.0:4444'
2026-08-03T19:26:05.751827+00:00 expensidev-2404 bedrock: xxxxxx we@dont.know (BedrockServer.cpp:2549) handleSocket [socket0] [info] [performance] Socket thread starting
2026-08-03T19:26:05.751940+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (BedrockServer.cpp:1594) getCommandFromPlugins [socket0] [dbug] Plugin Auth handling command Get ~~ command: 'Get'
2026-08-03T19:26:05.751984+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (BedrockServer.cpp:2526) buildCommandFromRequest [socket0] [dbug] Deserialized command Get ~~ command: 'Get'
2026-08-03T19:26:05.752108+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (libstuff.cpp:2829) SQuery [socket0_cmd] [dbug] PRAGMA legacy_file_format = OFF ~~ command: 'Get'
2026-08-03T19:26:05.752133+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (libstuff.cpp:2829) SQuery [socket0_cmd] [dbug] PRAGMA journal_mode = wal2; ~~ command: 'Get'
2026-08-03T19:26:05.752957+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SQLite.cpp:238) commonConstructorInitialization [socket0_cmd] [info] Setting cache_size to 10001KB ~~ command: 'Get'
2026-08-03T19:26:05.752981+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (libstuff.cpp:2829) SQuery [socket0_cmd] [dbug] PRAGMA cache_size = -10001; ~~ command: 'Get'
2026-08-03T19:26:05.752994+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SQLitePool.cpp:62) getIndex [socket0_cmd] [info] Returning new DB handle: 1 ~~ command: 'Get'
2026-08-03T19:26:05.753124+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (BedrockCore.cpp:53) getRemainingTime [socket0_cmd] [warn] Command Get timed out. ~~ command: 'Get'
2026-08-03T19:26:05.753610+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug]  ~~ command: 'Get'
2026-08-03T19:26:05.753633+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] SLogStackTrace(int) [0xb780acf06474] ~~ command: 'Get'
2026-08-03T19:26:05.753650+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] BedrockCore::getRemainingTime(std::unique_ptr<BedrockCommand, std::default_delete<BedrockCommand> > const&, bool) [0xb780acec8928] ~~ command: 'Get'
2026-08-03T19:26:05.753672+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] BedrockCore::isTimedOut(std::unique_ptr<BedrockCommand, std::default_delete<BedrockCommand> >&, SQLite*, BedrockServer const*) [0xb780acec8b7c] ~~ command: 'Get'
2026-08-03T19:26:05.753687+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] BedrockServer::runCommand(std::unique_ptr<BedrockCommand, std::default_delete<BedrockCommand> >&&, bool, bool) [0xb780accc5288] ~~ command: 'Get'
2026-08-03T19:26:05.753703+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /usr/sbin/bedrock(+0x1beb20) [0xb780accfeb20] ~~ command: 'Get'
2026-08-03T19:26:05.753714+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /usr/sbin/bedrock(+0x1beaa4) [0xb780accfeaa4] ~~ command: 'Get'
2026-08-03T19:26:05.753726+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /usr/sbin/bedrock(+0x1bea58) [0xb780accfea58] ~~ command: 'Get'
2026-08-03T19:26:05.753744+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /usr/sbin/bedrock(+0x1bea30) [0xb780accfea30] ~~ command: 'Get'
2026-08-03T19:26:05.753757+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /usr/sbin/bedrock(+0x1bea04) [0xb780accfea04] ~~ command: 'Get'
2026-08-03T19:26:05.753769+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /usr/sbin/bedrock(+0x1be950) [0xb780accfe950] ~~ command: 'Get'
2026-08-03T19:26:05.753786+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /lib/aarch64-linux-gnu/libstdc++.so.6(+0xe1ae0) [0xecc660ce1ae0] ~~ command: 'Get'
2026-08-03T19:26:05.753797+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /lib/aarch64-linux-gnu/libc.so.6(+0x8595c) [0xecc660ac595c] ~~ command: 'Get'
2026-08-03T19:26:05.753808+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SLog.cpp:22) SLogStackTrace [socket0_cmd] [dbug] /lib/aarch64-linux-gnu/libc.so.6(+0xeba4c) [0xecc660b2ba4c] ~~ command: 'Get'
2026-08-03T19:26:05.753819+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (libstuff.cpp:173) SException [socket0_cmd] [info] Throwing exception with message: '555 Timeout' from BedrockCore.cpp:57 ~~ command: 'Get'
2026-08-03T19:26:05.753834+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (BedrockCore.cpp:451) _handleCommandException [socket0_cmd] [info] Error processing command 'Get' (555 Timeout), ignoring. ~~ command: 'Get'
2026-08-03T19:26:05.753848+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (BedrockCommand.cpp:379) finalizeTimingInfo [socket0_cmd] [info] command 'Get_transactionList' timing info (ms): prePeek:0 (count: 0), peek:0 (count:0), process:0 (count:0), postProcess:0 (count:0), total:1, unaccounted:1, blockingCommitThreadTime:0, exclusiveTransactionLockTime:0. Commit: worker:0, sync:0. Queue: worker:0, sync:0, blocking:0, pageLock:0, escalation:0. Blocking: prePeek:0, peek:0, process:0, postProcess:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0. ~~ command: 'Get'
2026-08-03T19:26:05.753879+00:00 expensidev-2404 bedrock: nqxiAT ionatan@expensify.com (SQLitePool.cpp:90) returnToPool [socket0_cmd] [dbug] DB handle returned to pool. ~~ command: 'Get'
2026-08-03T19:26:05.754437+00:00 expensidev-2404 php-fpm: Xdebug: [Step Debug] Could not connect to debugging client. Tried: 10.2.2.1:9003 (from REMOTE_ADDR HTTP header), 10.2.2.1:9003 (fallback through xdebug.client_host/xdebug.client_port).
2026-08-03T19:26:05.768755+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [alrt] uncaught  Expensify\Bedrock\Exceptions\TimeoutError - eb2e3cf70b3ab6d0759f31f030d0b13a ~~ exceptionMessage: 'Internal Bedrock command timeout (555 Timeout)' exceptionFile: '/vagrant/Web-Expensify/vendor/expensify/bedrock-php/src/Client.php' exceptionLine: '779' exceptionCode: '0'
2026-08-03T19:26:05.768781+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] _send( expensidev-2404.web.log.alert:1|c )
2026-08-03T19:26:05.770200+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] DB_Analytics - Connecting to database. ~~ attemptNumber: '1' host: '127.0.0.1' dbName: 'analytics'
2026-08-03T19:26:05.773770+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [bench] Stop timing 'databases' / 'DB_Analytics' (took 3.6249160766602 ms)
2026-08-03T19:26:05.773790+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] DB_Analytics - INSERT INTO serverErrors( created, uuid, message, email, accountID, requestID, source ) VALUES( '2026-08-03 19:26:05', 'ALRT_718ed40f84e610effbbaf8d50384928d', 'uncaught  Expensify\\Bedrock\\Exceptions\\TimeoutError - eb2e3cf70b3ab6d0759f31f030d0b13a', 'ionatan@expensify.com', 4, 'nqxiAT', 'api' );
2026-08-03T19:26:05.773800+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] Benchmark started:DB_Analytics - Executing query
2026-08-03T19:26:05.775579+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] Benchmark finished:DB_Analytics - Executing query ~~ time: '0.0017328262329102'
2026-08-03T19:26:05.776364+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [trace] StackTrace start
2026-08-03T19:26:05.776380+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [trace] 0/4. file '/vagrant/Web-Expensify/vendor/expensify/bedrock-php/src/Client.php' function 'receiveResponse' line '504'
2026-08-03T19:26:05.776385+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [trace] 1/4. file '/vagrant/Web-Expensify/vendor/expensify/bedrock-php/src/Client.php' function 'doCall' line '359'
2026-08-03T19:26:05.776389+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [trace] 2/4. file '/vagrant/Web-Expensify/lib/Auth.php' function 'call' line '670'
2026-08-03T19:26:05.776393+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [trace] 3/4. file '/vagrant/Web-Expensify/lib/Auth.php' function 'call' line '864'
2026-08-03T19:26:05.776397+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [trace] 4/4. file '/vagrant/Web-Expensify/caca.php' function 'get' line '6'
2026-08-03T19:26:05.776401+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [trace] StackTrace end
2026-08-03T19:26:05.776972+00:00 expensidev-2404 php-fpm: Xdebug: [Step Debug] Could not connect to debugging client. Tried: 10.2.2.1:9003 (from REMOTE_ADDR HTTP header), 10.2.2.1:9003 (fallback through xdebug.client_host/xdebug.client_port).
2026-08-03T19:26:05.777597+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] StoreUtils - Clearing all the stores.
2026-08-03T19:26:05.777759+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] TransactionStore cache fully cleared
2026-08-03T19:26:05.777937+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] ReportStore cache cleared
2026-08-03T19:26:05.778255+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] NVPStore - clear cache
2026-08-03T19:26:05.778267+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] NVPStore - clear cache
2026-08-03T19:26:05.779448+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] SharedInNVPStore - clear cache
2026-08-03T19:26:05.780008+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] ReportDuplicatedTransactionsStore - Cache cleared
2026-08-03T19:26:05.781733+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] _send( expensidev-2404.web.auth.requests.GetrVLtransactionList:1|c )
2026-08-03T19:26:05.781748+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [dbug] _send( expensidev-2404.web.auth.lasthost.:1|c )
2026-08-03T19:26:05.781896+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] [bench] Bench totals for command  ~~ {"total":6,"_before":{"banhammer":{"total":0},"total":0,"count":1},"WAF":{"clean":{"total":2},"total":2,"count":1},"databases":{"DB_Analytics":{"total":4},"total":4,"count":1}}
2026-08-03T19:26:05.782061+00:00 expensidev-2404 php-fpm: nqxiAT /caca.php ionatan@expensify.com !web! ?api? [info] Profile ~~ {"total":80,"output":{"size":301,"gzip":1,"ratio":50},"gzip":301,"PHP":{"total":74,"%":92,"boot":47,"proc":27,"pack":0,"mem":2},"Auth":{"time":0,"%":0,"count":1,"requests":{"Get rVL='transactionList'":1},"size":0}}
```

### Related Issues
https://github.com/Expensify/Expensify/issues/667743
## Deployment

- [x] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
