### PR TITLE
Do not open the circuit breaker when only one host failed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.7",
+    "version": "2.3.6",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.5",
+    "version": "2.3.6",
     "authors": [
         {
             "name": "Expensify",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.6",
+    "version": "2.3.7",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -958,8 +958,8 @@ class Client implements LoggerAwareInterface
         if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return;
         }
-        // A single failed host is already handled by blacklisting it, so it must not trip the whole cluster.
-        if (count($this->failedHosts) < min(2, count($this->mainHostConfigs + $this->failoverHostConfigs))) {
+        // Blacklisting handles fewer, and the cluster only loses its leader once 3 nodes are unreachable.
+        if (count($this->failedHosts) < min(3, count($this->mainHostConfigs + $this->failoverHostConfigs))) {
             return;
         }
         $ttl = $this->circuitBreakerCooldown + 60;

--- a/src/Client.php
+++ b/src/Client.php
@@ -362,6 +362,10 @@ class Client implements LoggerAwareInterface
         }
         try {
             $response = $this->doCall($method, $headers, $body);
+        } catch (TimeoutError $e) {
+            // A timeout is never retried on another host, so it can never fail against all of them, but it still counts.
+            $this->recordCircuitFailure(true);
+            throw $e;
         } catch (BedrockError $e) {
             $this->recordCircuitFailure();
             throw $e;
@@ -950,13 +954,13 @@ class Client implements LoggerAwareInterface
      * the breaker never closes early) and the '-fails' count survives a burst, but short enough to
      * self-clean once traffic goes quiet.
      */
-    private function recordCircuitFailure(): void
+    private function recordCircuitFailure(bool $skipHostCheck = false): void
     {
         if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return;
         }
-        // A cluster only loses its leader once 3 nodes are unreachable; below that, blacklisting routes around them.
-        if (count($this->failedHosts) < min(3, count($this->mainHostConfigs + $this->failoverHostConfigs))) {
+        // While any host can still serve the call, blacklisting the bad ones is enough.
+        if (!$skipHostCheck && count($this->failedHosts) < count($this->failoverHostConfigs ?: $this->mainHostConfigs)) {
             return;
         }
         $ttl = $this->circuitBreakerCooldown + 60;

--- a/src/Client.php
+++ b/src/Client.php
@@ -960,7 +960,7 @@ class Client implements LoggerAwareInterface
         if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return;
         }
-        // The blacklist already steers us away from the hosts that failed, so while any host is left we don't count it here.
+        // Only count this failure toward the circuit-breaker threshold once every host is in the blacklist. Until then, the blacklist will route future requests to a healthy host, so the cluster as a whole isn't down yet.
         if (!$skipHostCheck && count($this->failedHosts) < count($this->failoverHostConfigs ?: $this->mainHostConfigs)) {
             return;
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -363,7 +363,7 @@ class Client implements LoggerAwareInterface
         try {
             $response = $this->doCall($method, $headers, $body);
         } catch (TimeoutError $e) {
-            // A timeout is never retried on another host, so it can never fail against all of them, but it still counts.
+            // A timeout doesn't mark the host as failed, so it records none and could never pass the check below.
             $this->recordCircuitFailure(true);
             throw $e;
         } catch (BedrockError $e) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -363,7 +363,7 @@ class Client implements LoggerAwareInterface
         try {
             $response = $this->doCall($method, $headers, $body);
         } catch (TimeoutError $e) {
-            // When a timeout happens, we don't retry the request, so we don't mark the host as failed. 
+            // When a timeout happens, we don't retry the request, so we don't mark the host as failed.
             // However, if all hosts are timing out, we need to trip the circuit breaker.
             $this->recordCircuitFailure(true);
             throw $e;

--- a/src/Client.php
+++ b/src/Client.php
@@ -958,7 +958,7 @@ class Client implements LoggerAwareInterface
         if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return;
         }
-        // Blacklisting handles fewer, and the cluster only loses its leader once 3 nodes are unreachable.
+        // A cluster only loses its leader once 3 nodes are unreachable; below that, blacklisting routes around them.
         if (count($this->failedHosts) < min(3, count($this->mainHostConfigs + $this->failoverHostConfigs))) {
             return;
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -363,8 +363,8 @@ class Client implements LoggerAwareInterface
         try {
             $response = $this->doCall($method, $headers, $body);
         } catch (TimeoutError $e) {
-            // When a timeout happens, we no longer mark the host as failed,
-            // but if all hosts are timing out, for the sake of circuit breaking, we want to keep track of this
+            // When a timeout happens, we don't retry the request, so we don't mark the host as failed. 
+            // However, if all hosts are timing out, we need to trip the circuit breaker.
             $this->recordCircuitFailure(true);
             throw $e;
         } catch (BedrockError $e) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -363,7 +363,8 @@ class Client implements LoggerAwareInterface
         try {
             $response = $this->doCall($method, $headers, $body);
         } catch (TimeoutError $e) {
-            // A timeout doesn't mark the host as failed, so it records none and could never pass the check below.
+            // When a timeout happens, we no longer mark the host as failed,
+            // but if all hosts are timing out, for the sake of circuit breaking, we want to keep track of this
             $this->recordCircuitFailure(true);
             throw $e;
         } catch (BedrockError $e) {
@@ -959,7 +960,7 @@ class Client implements LoggerAwareInterface
         if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
             return;
         }
-        // While any host can still serve the call, blacklisting the bad ones is enough.
+        // The blacklist already steers us away from the hosts that failed, so while any host is left we don't count it here.
         if (!$skipHostCheck && count($this->failedHosts) < count($this->failoverHostConfigs ?: $this->mainHostConfigs)) {
             return;
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -146,6 +146,11 @@ class Client implements LoggerAwareInterface
     private $circuitBreakerCooldown;
 
     /**
+     * @var array<string, true> Hosts the call in progress has failed against.
+     */
+    private $failedHosts = [];
+
+    /**
      * @var bool Set this to true to add a `mockRequest` header to all outgoing requests.
      */
     private $mockRequests;
@@ -442,6 +447,7 @@ class Client implements LoggerAwareInterface
         $rawRequest .= $body;
 
         $response = null;
+        $this->failedHosts = [];
         $preferredHost = null;
         if (isset($headers['host'])) {
             $preferredHost = $headers['host'];
@@ -889,6 +895,7 @@ class Client implements LoggerAwareInterface
      */
     private function markHostAsFailed(string $host)
     {
+        $this->failedHosts[$host] = true;
         if (!$this->maxBlackListTimeout) {
             return;
         }
@@ -949,6 +956,10 @@ class Client implements LoggerAwareInterface
     private function recordCircuitFailure(): void
     {
         if ($this->circuitBreakerThreshold <= 0 || !$this->isApcuAvailable()) {
+            return;
+        }
+        // A single failed host is already handled by blacklisting it, so it must not trip the whole cluster.
+        if (count($this->failedHosts) < min(2, count($this->mainHostConfigs + $this->failoverHostConfigs))) {
             return;
         }
         $ttl = $this->circuitBreakerCooldown + 60;


### PR DESCRIPTION
# Explanation of Change

The circuit breaker opened when a single node was down. We don't need the breaker to jump in here, only when many hosts are down or the cluster isn't responding.

### Related Issues

For https://github.com/Expensify/Bedrock-PHP/pull/258

For https://github.com/Expensify/Expensify/issues/657702

## Tests

AI tests below

---

No automated suite in this repo, so I ran a manual script in the Expensidev VM (dead loopback ports for unreachable nodes, local Bedrock on 8888 for healthy ones). 6/6:

```
 [PASS] 1: one failed host never opens it, failover still serves
 [PASS] 2: two failed hosts never open it
 [PASS] 3: three failed hosts open it at the threshold
 [PASS] 4: a dead cluster opens it at the threshold
 [PASS] 5: one dead host IS the whole cluster, so it opens
 [PASS] 6: a healthy call clears both keys
```

Phase 1 is the 2026-08-04 shape and fails on `main`. Happy to attach the script.

## Deployment

- [ ] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly

Version bump and tag still to come.
