### PR TITLE
[HOLD] Retry socket_select() when interrupted by a signal (EINTR)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.5",
+    "version": "2.3.6",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Client.php
+++ b/src/Client.php
@@ -608,14 +608,22 @@ class Client implements LoggerAwareInterface
             if ($socketErrorCode === 115) {
                 $this->logger->debug('Bedrock\Client - socket_connect returned error 115, waiting for connection to complete.', ['host' => $host]);
 
-                // Wait for the socket to be ready for writing after EINPROGRESS
-                $write = [$this->socket];
-                $read = [];
-                $except = [];
-                $selectResult = socket_select($read, $write, $except, $this->connectionTimeout, $this->connectionTimeoutMicroseconds);
+                // Wait for the socket to be ready for writing after EINPROGRESS, retrying if a signal interrupts the
+                // wait (EINTR), which says nothing about the health of the host. The deadline bounds those retries.
+                $deadline = microtime(true) + $this->connectionTimeout + $this->connectionTimeoutMicroseconds / 1000000;
+                do {
+                    $write = [$this->socket];
+                    $read = [];
+                    $except = [];
+                    $secondsLeft = max(0, $deadline - microtime(true));
+                    $selectResult = @socket_select($read, $write, $except, (int) $secondsLeft, (int) (($secondsLeft - (int) $secondsLeft) * 1000000));
+
+                    // socket_select() sets the global socket error, not the error of any individual socket.
+                    $wasInterrupted = $selectResult === false && socket_last_error() === SOCKET_EINTR;
+                } while ($wasInterrupted && $secondsLeft > 0);
 
                 if ($selectResult === false) {
-                    $socketError = socket_strerror(socket_last_error($this->socket));
+                    $socketError = socket_strerror(socket_last_error());
                     throw new ConnectionFailure("socket_select failed after EINPROGRESS for $host:$port. Error: $socketError");
                 } elseif ($selectResult === 0) {
                     throw new ConnectionFailure("Socket not ready for writing within timeout after EINPROGRESS for $host:$port");


### PR DESCRIPTION
HOLD while we monitor the original issue to check if this PR is really necessary

# Explanation of Change

During a non-blocking connect, `socket_connect()` returns `EINPROGRESS` (115) and we call `socket_select()` to wait for the socket to become writable. That wait can be interrupted by a signal (`EINTR`), which POSIX expects callers to retry — it says nothing about the health of the host.

`sendRawRequest()` treated any `false` return from `socket_select()` as fatal, which caused three problems on every occurrence:

1. A healthy Bedrock host got `markHostAsFailed()`'d and the request failed over to another host.
2. The un-suppressed `socket_select()` warning leaked a raw PHP Warning into the logs, tripping deploy-blocker detection.
3. The `ConnectionFailure` message read `socket_last_error($this->socket)`, which still holds the stale `EINPROGRESS`. That is why the logs read `Error: Operation now in progress` for what was actually `EINTR`. `socket_select()` reports its failure through the global socket error, so the message now reads that instead.

This PR retries the select when, and only when, it was interrupted by a signal. Retries are bounded by a wall-clock deadline computed once from `connectionTimeout`, so an EINTR storm cannot extend the effective connection timeout. Once the deadline passes, the select returns `0` immediately and the existing timeout `ConnectionFailure` is thrown as before. Every other failure mode keeps its current behavior.

Bumps the version to `2.3.6`.

### Related Issues

$ https://github.com/Expensify/Expensify/issues/665789

## Deployment

- [x] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
