### PR TITLE
Add a guard before accessing response code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.5",
+    "version": "2.3.6",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -23,7 +23,7 @@ class Cache extends Plugin
      *
      * @throws NotFound
      */
-    public function read($name, $version = null)
+    public function read(string $name, ?string $version = null)
     {
         $fullName = ($version ? "$name/$version" : "$name/*");
         $this->client->getLogger()->info('BedrockCache read', [

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -26,11 +26,11 @@ class Cache extends Plugin
     public function read($name, $version = null)
     {
         $fullName = ($version ? "$name/$version" : "$name/*");
-        $this->client->getLogger()->info("BedrockCache read", [
+        $this->client->getLogger()->info('BedrockCache read', [
             'key' => $name,
             'version' => $version,
         ]);
-        $response = $this->call("ReadCache", ["name" => $fullName]);
+        $response = $this->call('ReadCache', ['name' => $fullName]);
         if (!is_array($response) || $response['code'] === 404) {
             throw new NotFound('The cache entry could not be found', 666);
         }
@@ -39,14 +39,8 @@ class Cache extends Plugin
 
     /**
      * Reads from the cache, but if it does not find the entry, it returns the passed default.
-     *
-     * @param string $name
-     * @param mixed  $default
-     * @param string $version
-     *
-     * @return mixed
      */
-    public function readWithDefault($name, $default, $version = null)
+    public function readWithDefault(string $name, mixed $default, string $version = null): mixed
     {
         try {
             return $this->read($name, $version);
@@ -57,14 +51,8 @@ class Cache extends Plugin
 
     /**
      * Gets data from a cache, if it is not present, it computes it by calling $computeFunction and saves the result in the cache.
-     *
-     * @param string      $name
-     * @param null|string $version
-     * @param callable    $computeFunction
-     *
-     * @return array
      */
-    public function get(string $name, ?string $version, callable $computeFunction)
+    public function get(string $name, ?string $version, callable $computeFunction): array
     {
         try {
             return $this->read($name, $version);
@@ -96,14 +84,14 @@ class Cache extends Plugin
         // If we have a version, invalidate previous versions
         if ($version) {
             // Invalidate all other versions of this name before setting
-            $headers["invalidateName"] = "$name/*";
-            $headers["name"] = "$name/$version";
+            $headers['invalidateName'] = "$name/*";
+            $headers['name'] = "$name/$version";
         } else {
             // Just set this name
-            $headers["name"] = "$name/";
+            $headers['name'] = "$name/";
         }
 
-        $this->call("WriteCache", $headers, json_encode($value));
+        $this->call('WriteCache', $headers, json_encode($value));
     }
 
     /**

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -17,7 +17,7 @@ class Cache extends Plugin
      * version of that value, if available.
      *
      * @param string $name    Name pattern (using LIKE syntax) to read.
-     * @param string $version (optional) Specific version identifier (ie, a timestamp, counter, name, etc), defaults to the latest
+     * @param ?string $version (optional) Specific version identifier (ie, a timestamp, counter, name, etc), defaults to the latest
      *
      * @return mixed Whatever was saved in the cache
      *
@@ -72,9 +72,9 @@ class Cache extends Plugin
      *
      * @param string $name    Arbitrary string used to uniquely name this value.
      * @param mixed  $value   Raw binary data to associate with this name
-     * @param string $version (optional) Version identifier (eg, a timestamp, counter, name, etc)
+     * @param ?string $version (optional) Version identifier (eg, a timestamp, counter, name, etc)
      */
-    public function write($name, $value, $version = null, array $headers = [])
+    public function write(string $name, mixed $value, ?string $version = null, array $headers = [])
     {
         // By default, unless specified otherwise, we want writes to be async
         $headers = array_merge([
@@ -97,11 +97,9 @@ class Cache extends Plugin
     /**
      * Call the bedrock cache methods, and handle connection error.
      *
-     * @param string $body
-     *
      * @return mixed|null
      */
-    private function call(string $method, array $headers, $body = '')
+    private function call(string $method, array $headers, string $body = '')
     {
         // Both writing to and reading from the cache are always idempotent operations
         $headers['idempotent'] = true;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -16,7 +16,7 @@ class Cache extends Plugin
      * Reads a named value from the cache.  Can optionally request a specific
      * version of that value, if available.
      *
-     * @param string $name    Name pattern (using LIKE syntax) to read.
+     * @param string  $name    Name pattern (using LIKE syntax) to read.
      * @param ?string $version (optional) Specific version identifier (ie, a timestamp, counter, name, etc), defaults to the latest
      *
      * @return mixed Whatever was saved in the cache
@@ -70,8 +70,8 @@ class Cache extends Plugin
      * successfully queued with the server, but before the write itself has
      * completed).
      *
-     * @param string $name    Arbitrary string used to uniquely name this value.
-     * @param mixed  $value   Raw binary data to associate with this name
+     * @param string  $name    Arbitrary string used to uniquely name this value.
+     * @param mixed   $value   Raw binary data to associate with this name
      * @param ?string $version (optional) Version identifier (eg, a timestamp, counter, name, etc)
      */
     public function write(string $name, mixed $value, ?string $version = null, array $headers = [])

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -31,7 +31,7 @@ class Cache extends Plugin
             'version' => $version,
         ]);
         $response = $this->call("ReadCache", ["name" => $fullName]);
-        if ($response['code'] === 404) {
+        if (!is_array($response) || $response['code'] === 404) {
             throw new NotFound('The cache entry could not be found', 666);
         }
         return $response['body'];

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -40,7 +40,7 @@ class Cache extends Plugin
     /**
      * Reads from the cache, but if it does not find the entry, it returns the passed default.
      */
-    public function readWithDefault(string $name, mixed $default, string $version = null): mixed
+    public function readWithDefault(string $name, mixed $default, ?string $version = null): mixed
     {
         try {
             return $this->read($name, $version);


### PR DESCRIPTION
<!-- Assign PullerBear for review and anyone else that knows the area or changes well. -->

# Explanation of Change
Same as title 


### Related Issues
$ https://github.com/Expensify/Expensify/issues/669799

## Deployment

- [x] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
