### PR TITLE
Add unique-as-retry support to Bedrock-PHP and BWM

### DIFF
--- a/bin/BedrockWorkerManager.php
+++ b/bin/BedrockWorkerManager.php
@@ -322,6 +322,7 @@ try {
                 $job['name'] = $jobParts[0];
                 $workerName = explode('/', $job['name'])[1];
                 $workerFilename = $workerPath."/$workerName.php";
+                $enqueueVersion = isset($job['enqueueVersion']) ? (int) $job['enqueueVersion'] : null;
                 $stats->timer('bedrockJob.lateBy.'.$job['name'], (time() - strtotime($job['nextRun'])) * 1000);
                 if (file_exists($workerFilename)) {
                     // The file seems to exist -- fork it so we can run it.
@@ -396,7 +397,7 @@ try {
                         // that we automatically pick up new versions over the
                         // worker without needing to restart the parent.
                         include_once $workerFilename;
-                        $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrock, $jobs, $job, $extraParams, $logger, $localDB, $enableLoadHandler, $localJobID, $stats, $jobStartTime) {
+                        $stats->benchmark('bedrockJob.finish.'.$job['name'], function () use ($workerName, $bedrock, $jobs, $job, $enqueueVersion, $extraParams, $logger, $localDB, $enableLoadHandler, $localJobID, $stats, $jobStartTime) {
                             $worker = new $workerName($bedrock, $job);
 
                             // Open the DB connection after the fork in the child process.
@@ -420,7 +421,7 @@ try {
                                 }
 
                                 try {
-                                    $jobs->finishJob((int) $job['jobID'], $worker->getData());
+                                    $jobs->finishJob((int) $job['jobID'], $worker->getData(), $enqueueVersion);
                                 } catch (DoesNotExist $e) {
                                     // Job does not exist, but we know it had to exist because we were running it, so
                                     // we assume this is happening because we retried the command in a different server
@@ -447,7 +448,7 @@ try {
                                     'exception' => $e,
                                 ]);
                                 try {
-                                    $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun(), null, $e->getIgnoreRepeat());
+                                    $jobs->retryJob((int) $job['jobID'], $e->getDelay(), $worker->getData(), $e->getName(), $e->getNextRun(), null, $e->getIgnoreRepeat(), $enqueueVersion);
                                 } catch (IllegalAction|DoesNotExist $e) {
                                     // IllegalAction is returned when we try to finish a job that's not RUNNING, this
                                     // can happen if we retried the command in a different server
@@ -463,7 +464,7 @@ try {
                                 ]);
                                 // Worker had a fatal error -- mark as failed.
                                 try {
-                                    $jobs->failJob((int) $job['jobID']);
+                                    $jobs->failJob((int) $job['jobID'], $enqueueVersion);
                                 } catch (IllegalAction|DoesNotExist $e) {
                                     // IllegalAction is returned when we try to finish a job that's not RUNNING, this
                                     // can happen if we retried the command in a different server
@@ -498,7 +499,7 @@ try {
                 } else {
                     // No worker for this job
                     $logger->warning('No worker found, ignoring', ['jobName' => $job['name']]);
-                    $jobs->failJob((int) $job['jobID']);
+                    $jobs->failJob((int) $job['jobID'], $enqueueVersion);
                 }
             }
         } elseif ($response['code'] == 303) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "expensify/bedrock-php",
     "description": "Bedrock PHP Library",
     "type": "library",
-    "version": "2.3.6",
+    "version": "2.3.7",
     "authors": [
         {
             "name": "Expensify",

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -443,7 +443,8 @@ class Jobs extends Plugin
      *         . lastRun - timestamp it was last run
      *         . repeat - recurring description
      *         . data - JSON data associated with this job.
-     *         . enqueueVersion - version to echo when finishing, retrying, or failing an opted-in unique job
+     *         . enqueueVersion - latest enqueue version for an opted-in unique job. This value is for status only.
+     *           Worker completion requires the version from the GetJob or GetJobs dequeue response.
      *
      * @param int $jobID
      *

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -122,13 +122,13 @@ class Jobs extends Plugin
      * @param array  $headers Headers to send
      * @param string $body    Body of the request
      *
+     * @return array
+     *
      * @throws DoesNotExist
      * @throws IllegalAction
      * @throws MalformedAttribute
      * @throws SqlFailed
      * @throws GenericError
-     *
-     * @return array
      */
     public function call($method, $headers = [], $body = '')
     {
@@ -177,19 +177,20 @@ class Jobs extends Plugin
      * Schedules a new job, optionally in the future, optionally to repeat.
      *
      * @param string      $name
-     * @param array|null  $data        (optional)
-     * @param string|null $firstRun    (optional)
-     * @param string|null $repeat      (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
-     * @param bool|null   $unique      (optional) Do we want only one job with this name to exist?
-     * @param int|null    $priority    (optional) Specify a job priority. Jobs with higher priorities will be run first.
-     * @param int|null    $parentJobID (optional) Specify this job's parent job.
-     * @param string|null $connection  (optional) Specify 'Connection' header using constants defined in this class.
-     * @param string|null $retryAfter  (optional) Specify after what time in RUNNING this job should be retried (same syntax as repeat)
-     * @param bool        $overwrite   (optional) Only applicable when unique is is true. When set to true it will overwrite the existing job with the new jobs data
+     * @param array|null  $data          (optional)
+     * @param string|null $firstRun      (optional)
+     * @param string|null $repeat        (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param bool|null   $unique        (optional) Do we want only one job with this name to exist?
+     * @param int|null    $priority      (optional) Specify a job priority. Jobs with higher priorities will be run first.
+     * @param int|null    $parentJobID   (optional) Specify this job's parent job.
+     * @param string|null $connection    (optional) Specify 'Connection' header using constants defined in this class.
+     * @param string|null $retryAfter    (optional) Specify after what time in RUNNING this job should be retried (same syntax as repeat)
+     * @param bool        $overwrite     (optional) Only applicable when unique is is true. When set to true it will overwrite the existing job with the new jobs data
+     * @param bool        $uniqueAsRetry (optional) Requeue a running unique job when a newer enqueue updates it
      *
      * @return array Containing "jobID"
      */
-    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, $retryAfter = null, $overwrite = true)
+    public function createJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, $retryAfter = null, $overwrite = true, $uniqueAsRetry = false)
     {
         $this->client->getLogger()->info('Create job', ['name' => $name]);
         $commitCounts = Client::getCommitCounts();
@@ -210,6 +211,7 @@ class Jobs extends Plugin
                 'idempotent' => $unique,
                 'retryAfter' => $retryAfter,
                 'overwrite' => $overwrite,
+                'uniqueAsRetry' => $uniqueAsRetry,
             ]
         );
 
@@ -221,7 +223,7 @@ class Jobs extends Plugin
     /**
      * Schedules a list of jobs.
      *
-     * @param array  $jobs       JSON array containing each job. Each job should include the same parameters as jobs define in CreateJob
+     * @param array  $jobs       JSON array containing each job. Each job should include the same parameters as jobs defined in CreateJob, including optional uniqueAsRetry
      * @param string $connection (optional) Specify 'Connection' header using constants defined in this class.
      *
      * @return array - contain the jobIDs with the unique identifier of the created jobs
@@ -321,12 +323,13 @@ class Jobs extends Plugin
     /**
      * Marks a job as finished, which causes it to repeat if requested.
      *
-     * @param int   $jobID
-     * @param array $data  (optional)
+     * @param int      $jobID
+     * @param array    $data           (optional)
+     * @param int|null $enqueueVersion (optional) Version returned when the job was dequeued
      *
      * @return array
      */
-    public function finishJob($jobID, $data = null)
+    public function finishJob($jobID, $data = null, ?int $enqueueVersion = null)
     {
         return $this->call(
             'FinishJob',
@@ -334,6 +337,7 @@ class Jobs extends Plugin
                 'jobID' => $jobID,
                 'data' => $data,
                 'idempotent' => true,
+                'enqueueVersion' => $enqueueVersion,
             ]
         );
     }
@@ -372,25 +376,29 @@ class Jobs extends Plugin
     /**
      * Mark a job as failed.
      *
-     * @param int $jobID
+     * @param int      $jobID
+     * @param int|null $enqueueVersion (optional) Version returned when the job was dequeued
      *
      * @return array
      */
-    public function failJob($jobID)
+    public function failJob($jobID, ?int $enqueueVersion = null)
     {
         return $this->call(
             'FailJob',
             [
                 'jobID' => $jobID,
                 'idempotent' => true,
+                'enqueueVersion' => $enqueueVersion,
             ]
         );
     }
 
     /**
      * Retry a job. Job must be in a RUNNING state to be able to be retried.
+     *
+     * @param int|null $enqueueVersion (optional) Version returned when the job was dequeued
      */
-    public function retryJob(int $jobID, int $delay = 0, array $data = null, string $name = '', string $nextRun = '', ?int $priority = null, bool $ignoreRepeat = false): array
+    public function retryJob(int $jobID, int $delay = 0, ?array $data = null, string $name = '', string $nextRun = '', ?int $priority = null, bool $ignoreRepeat = false, ?int $enqueueVersion = null): array
     {
         return $this->call(
             'RetryJob',
@@ -403,6 +411,7 @@ class Jobs extends Plugin
                 'idempotent' => true,
                 'jobPriority' => $priority,
                 'ignoreRepeat' => $ignoreRepeat,
+                'enqueueVersion' => $enqueueVersion,
             ]
         );
     }
@@ -434,6 +443,7 @@ class Jobs extends Plugin
      *         . lastRun - timestamp it was last run
      *         . repeat - recurring description
      *         . data - JSON data associated with this job.
+     *         . enqueueVersion - version to echo when finishing, retrying, or failing an opted-in unique job
      *
      * @param int $jobID
      *
@@ -457,24 +467,26 @@ class Jobs extends Plugin
      * Silently fails in case of an exception and logs the error.
      *
      * @param string      $name
-     * @param array|null  $data        (optional)
-     * @param string|null $firstRun    (optional)
-     * @param string|null $repeat      (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
-     * @param bool        $unique      Do we want only one job with this name to exist?
-     * @param int         $priority    (optional) Specify a job priority. Jobs with higher priorities will be run first.
-     * @param int|null    $parentJobID (optional) Specify this job's parent job.
-     * @param string      $connection  (optional) Specify 'Connection' header using constants defined in this class.
-     * @param bool        $overwrite   (optional) Only applicable when unique is is true. When set to true it will overwrite the existing job with the new jobs data
+     * @param array|null  $data          (optional)
+     * @param string|null $firstRun      (optional)
+     * @param string|null $repeat        (optional) see https://github.com/Expensify/Bedrock/blob/master/plugins/Jobs.md#repeat-syntax
+     * @param bool        $unique        Do we want only one job with this name to exist?
+     * @param int         $priority      (optional) Specify a job priority. Jobs with higher priorities will be run first.
+     * @param int|null    $parentJobID   (optional) Specify this job's parent job.
+     * @param string      $connection    (optional) Specify 'Connection' header using constants defined in this class.
+     * @param string      $retryAfter    (optional) Specify after what time in RUNNING this job should be retried
+     * @param bool        $overwrite     (optional) Only applicable when unique is is true. When set to true it will overwrite the existing job with the new jobs data
+     * @param bool        $uniqueAsRetry (optional) Requeue a running unique job when a newer enqueue updates it
      *
      * @return array Containing "jobID"
      */
-    public static function queueJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, string $retryAfter = '', bool $overwrite = true)
+    public static function queueJob($name, $data = null, $firstRun = null, $repeat = null, $unique = false, $priority = self::PRIORITY_MEDIUM, $parentJobID = null, $connection = self::CONNECTION_WAIT, string $retryAfter = '', bool $overwrite = true, bool $uniqueAsRetry = false)
     {
         $bedrock = Client::getInstance();
         try {
             $jobs = new self($bedrock);
 
-            return $jobs->createJob($name, $data, $firstRun, $repeat, $unique, $priority, $parentJobID, $connection, $retryAfter, $overwrite);
+            return $jobs->createJob($name, $data, $firstRun, $repeat, $unique, $priority, $parentJobID, $connection, $retryAfter, $overwrite, $uniqueAsRetry);
         } catch (Exception $e) {
             $bedrock->getLogger()->alert('Could not create Bedrock job', ['exception' => $e]);
 


### PR DESCRIPTION
<!-- Assign PullerBear for review and anyone else that knows the area or changes well. -->

# Explanation of Change

<!-- Explain what your change does and how it addresses the linked issue -->

Extends the Jobs client with uniqueAsRetry and enqueueVersion parameters, then updates BWM to return each job’s starting version when finishing or retrying it. This allows Bedrock to detect stale worker results and preserve newer enqueue data.

### Related Issues

https://github.com/Expensify/Expensify/issues/670760

https://github.com/Expensify/Bedrock/pull/2723

## Deployment


- [x] I followed the steps in the [README](../blob/main/README.md#publishing-your-changes) to ensure this PR is deployed properly
