### PR TITLE
Fetch tags with fetch-depth 0 so the release can find them

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -36,11 +36,17 @@ jobs:
           --jq '([.[] | select(.merge_commit_sha == "${{ github.sha }}")] + .) | .[0].html_url' || true)"
         echo "PR_URL=$PR_URL" >> "$GITHUB_ENV"
 
+    - name: checkout
+      # v4.1.0
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      with:
+        # 0 fetches all history and tags, which is where the next version comes from.
+        fetch-depth: 0
+
     - name: Get next version
       run: |
         set -euo pipefail
-        LATEST_VERSION="$(gh api --paginate "repos/${{ github.repository }}/tags?per_page=100" --jq '.[].name' \
-          | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -rV | head -1 || true)"
+        LATEST_VERSION="$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
         if [ -z "$LATEST_VERSION" ]; then
           echo "Found no version tag to increment."
           exit 1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,10 +1,11 @@
 name: Create new version
 
-# Runs when a pull request is merged into main. It tags the merge commit with
-# the next patch version and comments the released version on the pull request.
+# Runs when a pull request is merged into main, or manually to release a merge
+# that missed its tag. Tags the commit and comments the version on the pull request.
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   actions: read
@@ -35,17 +36,11 @@ jobs:
           --jq '([.[] | select(.merge_commit_sha == "${{ github.sha }}")] + .) | .[0].html_url' || true)"
         echo "PR_URL=$PR_URL" >> "$GITHUB_ENV"
 
-    - name: checkout
-      # v4.1.0
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      with:
-        # The next version is derived from the tags, and nothing reads the tree.
-        fetch-tags: true
-
     - name: Get next version
       run: |
         set -euo pipefail
-        LATEST_VERSION="$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
+        LATEST_VERSION="$(gh api --paginate "repos/${{ github.repository }}/tags?per_page=100" --jq '.[].name' \
+          | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -rV | head -1 || true)"
         if [ -z "$LATEST_VERSION" ]; then
           echo "Found no version tag to increment."
           exit 1


### PR DESCRIPTION
# Explanation of Change

The bump version failed because it didn't pull in the latest tags, and apparently with fetch-depth 0, it should fix that. Also adding a way to manually create a new release if needed too.

### Related Issues

N/A

## Deployment

- [ ] Once this merges and a version is tagged, I will bump the `expensify/bedrock-php` constraint in Web-Expensify and Web-Secure if they need this change.
