### PR TITLE
Handle jobs with names that are too long

### DIFF
--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -18,6 +18,11 @@ use stdClass;
 class Jobs extends Plugin
 {
     /**
+     * Maximum length accepted by Bedrock for a job name, in bytes.
+     */
+    public const MAX_NAME_LENGTH = 255;
+
+    /**
      * Date format for $firstRun.
      *
      * @var string
@@ -132,6 +137,16 @@ class Jobs extends Plugin
      */
     public function call($method, $headers = [], $body = '')
     {
+        if (($method === 'CreateJob' || $method === 'GetJob') && isset($headers['name']) && is_string($headers['name'])) {
+            $headers['name'] = $this->truncateNameAndLog($headers['name']);
+        } elseif ($method === 'CreateJobs' && isset($headers['jobs']) && is_array($headers['jobs'])) {
+            foreach ($headers['jobs'] as $i => $job) {
+                if (isset($job['name']) && is_string($job['name'])) {
+                    $headers['jobs'][$i]['name'] = $this->truncateNameAndLog($job['name']);
+                }
+            }
+        }
+
         // If we ever pass an empty array as data, PHP will json encode it as an array, but data expects an object and
         // will generate a warning if it receives an array, so we pass an stdClass, which will get encoded as object
         if (isset($headers['data']) && is_array($headers['data']) && empty($headers['data'])) {
@@ -171,6 +186,32 @@ class Jobs extends Plugin
         }
 
         return $response;
+    }
+
+    /**
+     * Bedrock rejects job names over 255 bytes, so collapse the overflow into a deterministic hash. This preserves
+     * the worker prefix and ensures unique jobs continue to dedupe across producers.
+     */
+    public static function truncateName(string $name): string
+    {
+        if (strlen($name) <= self::MAX_NAME_LENGTH) {
+            return $name;
+        }
+
+        return substr($name, 0, self::MAX_NAME_LENGTH - 33).'~'.md5($name);
+    }
+
+    private function truncateNameAndLog(string $name): string
+    {
+        $truncatedName = self::truncateName($name);
+        if ($truncatedName !== $name) {
+            $this->client->getLogger()->notice('Replacing Bedrock job name because it exceeds the maximum length', [
+                'originalJobName' => $name,
+                'replacementJobName' => $truncatedName,
+            ]);
+        }
+
+        return $truncatedName;
     }
 
     /**


### PR DESCRIPTION
<!-- Assign PullerBear for review and anyone else that knows the area or changes well. -->

# Explanation of Change

We sometimes concatenate emails to the job name and other data that in rare cases can make the job's name longer than 255. When that happens, we fail the job creation:

`Could not create Bedrock job ~~ exception: 'Expensify\Bedrock\Exceptions\Jobs\MalformedAttribute: Malformed attribute. Job :www-prod/ConciergeSummaryEmail?email=sjjssjdjdjdjdjdjjeiwiwiwowkdjdjdieikdjfidekjcjdkekejdcjdkeekcjab@asjjssjdjdjdjdjdjjeiwiwiwowkdjdjdieikdjfidekjcjdkekejdcjdkeekcj.com.a.aa.asjjssjdjdjdjdjdjjeiwiwiwowkdjdjdieikdjfidekjcjdkekejdcjdkeekcj.asjjssjdjdjdjdjdjjeiwiwiwowkdjdjdieikdjfidekjcjasfff, message: 402 Malformed name in /git/releases/expensify.com/a2463f0/vendor/expensify/bedrock-php/src/Jobs.php:153Stack trace:#0 /git/releases/expensify.com/a2463f0/vendor/expensify/bedrock-php/src/Jobs.php(197): Expensify\Bedrock\Jobs->call() #1 /git/releases/expensify.com/a2463f0/vendor/expensify/bedrock-php/src/Jobs.php(477): Expensify\Bedrock\Jobs->createJob() #2 /git/releases/expensify.com/a2463f0/script/bwm/UserActivityEvaluator.php(365): Expensify\Bedrock\Jobs::queueJob() #3 /git/releases/expensify.com/a2463f0/script/bwm/UserActivityEvaluator.php(340): UserActivityEvaluator->queueConciergeSummaryEmail() #4 /git/releases/expensify.com/a2463f0/script/bwm/UserActivityEvaluator.php(304): UserActivityEvaluator->promoteTaskInConcierge() #5 /git/releases/expensify.com/a2463f0/script/bwm/UserActivityEvaluator.php(203): UserActivityEvaluator->promoteTask() #6 /git/releases/expensify.com/a2463f0/script/bwm/UserActivityEvaluator.php(111): UserActivityEvaluator->evaluateUser()#7 /git/releases/expensify.com/a2463f0/script/bwm/BedrockWorker.php(254): UserActivityEvaluator->{closure}()#8 /git/releases/expensify.com/a2463f0/script/bwm/UserActivityEvaluator.php(59): BedrockWorker->catchAndRetryBedrockErrors(Object(Closure))#9 /git/releases/expensify.com/a2463f0/vendor/expensify/bedrock-php/bin/BedrockWorkerManager.php(406): UserActivityEvaluator->run()#10 /git/releases/expensify.com/a2463f0/vendor/expensify/php-libs/src/StatsD.php(218): {closure}()#11 /git/releases/expensify.com/a2463f0/lib/BedockStatsD.php(19): Expensify\Libs\StatsD::benchmark() #12 /git/releases/expensify.com/a2463f0/lib/Bench.php(120): Expensify\BedockStatsD::Expensify\{closure}()#13 /git/releases/expensify.com/a2463f0/lib/BedockStatsD.php(19): Bench::measure() #14 /git/releases/expensify.com/a2463f0/vendor/expensify/bedrock-php/bin/BedrockWorkerManager.php(399): Expensify\BedockStatsD::benchmark() #15 /git/releases/expensify.com/a2463f0/vendor/bin/BedrockWorkerManager.php(18): include() #16 {main}'`

Logs: https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:=%22s0yIXP%22+_time:[2026-08-25T12:21:18.666Z,+2026-08-25T14:21:18.666Z]&index=victorialogs&engine=victorialogs

### Related Issues

https://github.com/Expensify/Expensify/issues/674285

## Deployment

- [ ] Once this merges and a version is tagged, I will bump the `expensify/bedrock-php` constraint in Web-Expensify and Web-Secure if they need this change.
